### PR TITLE
fix(frontend): remove inline comment in css

### DIFF
--- a/packages/frontend/CHANGELOG.md
+++ b/packages/frontend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.0.2-beta.4, 2025-03-19
+
+### Notable Changes
+
+- fix
+  - remove inline comment in css
+
+### Commits
+
+- \[[`313563e4eb`](https://github.com/twreporter/congress-dashboard-monorepo/commit/313563e4eb)] - **fix(frontend)**: remove inline comment in css (Aylie Chou)
+
 ## 0.0.2-beta.3, 2025-03-18
 
 ### Notable Changes

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/congress-dashboard-frontend",
-  "version": "0.0.2-beta.3",
+  "version": "0.0.2-beta.4",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/packages/frontend/src/components/dashboard/index.tsx
+++ b/packages/frontend/src/components/dashboard/index.tsx
@@ -91,9 +91,7 @@ const LoadMore = styled(PillButton)`
   `}
 `
 const sidebarCss = css<{ $show: boolean }>`
-  transform: translateX(
-    ${(props) => (props.$show ? 0 : 520)}px
-  ); //sidebar width 520px
+  transform: translateX(${(props) => (props.$show ? 0 : 520)}px);
   transition: transform 0.5s ease-in-out;
 
   position: fixed;


### PR DESCRIPTION
# Issue
`yarn build` version style is different from `yaen dev` version
because the inline comment in css would cause css under comments all removed

# Dependency
N/A