### PR TITLE
fix(frontend): add header max top and hidden print for toolbar

### DIFF
--- a/packages/frontend/CHANGELOG.md
+++ b/packages/frontend/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.0.2-beta.5, 2025-03-19
+
+### Notable Changes
+
+- fix
+  - add header max top and hidden print for toolbar
+
+### Commits
+
+- [[`7fbcd57147`](https://github.com/twreporter/congress-dashboard-monorepo/commit/7fbcd57147)] - Merge remote-tracking branch 'upstream/dev' into fix/frontend-speech-defetc-1 (Lucien)
+- [[`3979b03610`](https://github.com/twreporter/congress-dashboard-monorepo/commit/3979b03610)] - **fix(frontend)**: add header max top and hidden print for toolbar (Lucien)
+
 ## 0.0.2-beta.4, 2025-03-19
 
 ### Notable Changes
@@ -9,7 +21,7 @@
 
 ### Commits
 
-- \[[`313563e4eb`](https://github.com/twreporter/congress-dashboard-monorepo/commit/313563e4eb)] - **fix(frontend)**: remove inline comment in css (Aylie Chou)
+- [[`313563e4eb`](https://github.com/twreporter/congress-dashboard-monorepo/commit/313563e4eb)] - **fix(frontend)**: remove inline comment in css (Aylie Chou)
 
 ## 0.0.2-beta.3, 2025-03-18
 
@@ -55,7 +67,7 @@
 
 ###
 
-- \[[`6d2d137b83`](https://github.com/twreporter/congress-dashboard-monorepo/commit/6d2d137b83)] - **fix(frontend)**: build failed problem (Aylie Chou)
+- [[`6d2d137b83`](https://github.com/twreporter/congress-dashboard-monorepo/commit/6d2d137b83)] - **fix(frontend)**: build failed problem (Aylie Chou)
 
 ## 0.0.2-beta.1, 2025-03-18
 
@@ -68,11 +80,11 @@
 
 ### Commits
 
-- \[[`c7a8f86d32`](https://github.com/twreporter/congress-dashboard-monorepo/commit/c7a8f86d32)] - **fix(frontend)**: use correct icon in `titleSection` (Aylie Chou)
-- \[[`82e2ba5930`](https://github.com/twreporter/congress-dashboard-monorepo/commit/82e2ba5930)] - **chore(frontend)**: update @twreporter packages (Aylie Chou)
-- \[[`5c2d6a14cb`](https://github.com/twreporter/congress-dashboard-monorepo/commit/5c2d6a14cb)] - **fix(frontend)**: style defects in home page (Aylie Chou)
-- \[[`83b44ebddb`](https://github.com/twreporter/congress-dashboard-monorepo/commit/83b44ebddb)] - **fix(frontend)**: add horizontal gap for interaction (Aylie Chou)
-- \[[`f04ed98ee6`](https://github.com/twreporter/congress-dashboard-monorepo/commit/f04ed98ee6)] - **feat**: add sidebar components & stories (Aylie Chou)
+- [[`c7a8f86d32`](https://github.com/twreporter/congress-dashboard-monorepo/commit/c7a8f86d32)] - **fix(frontend)**: use correct icon in `titleSection` (Aylie Chou)
+- [[`82e2ba5930`](https://github.com/twreporter/congress-dashboard-monorepo/commit/82e2ba5930)] - **chore(frontend)**: update @twreporter packages (Aylie Chou)
+- [[`5c2d6a14cb`](https://github.com/twreporter/congress-dashboard-monorepo/commit/5c2d6a14cb)] - **fix(frontend)**: style defects in home page (Aylie Chou)
+- [[`83b44ebddb`](https://github.com/twreporter/congress-dashboard-monorepo/commit/83b44ebddb)] - **fix(frontend)**: add horizontal gap for interaction (Aylie Chou)
+- [[`f04ed98ee6`](https://github.com/twreporter/congress-dashboard-monorepo/commit/f04ed98ee6)] - **feat**: add sidebar components & stories (Aylie Chou)
 
 ## 0.0.2-beta.0, 2025-03-18
 
@@ -83,7 +95,7 @@
 
 ### Commits
 
-- \[[`f5c959c355`](https://github.com/twreporter/congress-dashboard-monorepo/commit/f5c959c355)] - **feat**: add search bar to header & hamburger menu (Aylie Chou)
+- [[`f5c959c355`](https://github.com/twreporter/congress-dashboard-monorepo/commit/f5c959c355)] - **feat**: add search bar to header & hamburger menu (Aylie Chou)
 
 ## 0.0.1-beta.14, 2025-03-07
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/congress-dashboard-frontend",
-  "version": "0.0.2-beta.4",
+  "version": "0.0.2-beta.5",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/packages/frontend/src/components/header/index.tsx
+++ b/packages/frontend/src/components/header/index.tsx
@@ -43,7 +43,7 @@ const Container = styled.header.attrs<{
 }>((props) => ({
   style: {
     top: props.$isHidden
-      ? `calc(${props.$tabTop}px - ${HEADER_HEIGHT}px)`
+      ? `max(calc(${props.$tabTop}px - ${HEADER_HEIGHT}px), -${HEADER_HEIGHT}px)`
       : '0px',
   },
 }))`

--- a/packages/frontend/src/components/speech/index.tsx
+++ b/packages/frontend/src/components/speech/index.tsx
@@ -236,6 +236,7 @@ const SpeechPage: React.FC<SpeechPageProps> = ({ slug }) => {
   return (
     <SpeechContainer>
       <ControlTabContainer
+        className="hidden-print"
         $isHeaderHidden={isHeaderHidden}
         $isHidden={isControllBarHidden}
       >
@@ -351,7 +352,7 @@ const SpeechPage: React.FC<SpeechPageProps> = ({ slug }) => {
           </Feedback>
         </DesktopAndAboveWithFlex>
       </BodyContainer>
-      <TabletAndBelow>
+      <TabletAndBelow className="hidden-print">
         <SpeechMobileToolbar
           onFontSizeChange={cycleFontSize}
           iVODLink={testSpeechData[slug].iVODLink}


### PR DESCRIPTION
# Issue
Add a `max()` for the header `top` css to improve performance and hide the mobile toolbar while printing.

# Notice
<!-- Related notice or note for this PR -->

# Dependency
<!-- Related dependency of this PR -->
