### PR TITLE
fix: copy public env when cloud build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -29,6 +29,10 @@ steps:
 
         cd packages/$_TARGET_PACKAGE
 
+        echo 'copy .env.${BRANCH_NAME}.public to .env.local'
+
+        cp .env.${BRANCH_NAME}.public .env.local
+
         docker build -t \
 
         gcr.io/$PROJECT_ID/$_IMAGE_NAME:${BRANCH_NAME}_${SHORT_SHA} \

--- a/packages/frontend/.env.dev.public
+++ b/packages/frontend/.env.dev.public
@@ -1,0 +1,3 @@
+NEXT_PUBLIC_RELEASE_BRANCH=dev
+NEXT_PUBLIC_API_URL=https://dev-congress-dashboard.twreporter.org/api/graphql
+NEXT_PUBLIC_IMAGE_HOST=https://dev-congress-dashboard-storage.twreporter.org

--- a/packages/frontend/.gitignore
+++ b/packages/frontend/.gitignore
@@ -31,7 +31,7 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env.local
 
 # vercel
 .vercel

--- a/packages/frontend/CHANGELOG.md
+++ b/packages/frontend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.0.2-beta.12, 2025-03-24
+
+### Notable Changes
+
+- fix
+  - copy public env when cloud build
+
+### Commits
+
+- [[`71901b318c`](https://github.com/twreporter/congress-dashboard-monorepo/commit/71901b318c)] - **fix**: copy public env when cloud build (Aylie Chou)
+
 ## 0.0.2-beta.11, 2025-03-21
 
 ### Notable Changes

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/congress-dashboard-frontend",
-  "version": "0.0.2-beta.11",
+  "version": "0.0.2-beta.12",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
# Issue
cannot get cms data from frontend

# Notice
use the same method as [kids-reporter-monorepo](https://github.com/kids-reporter/kids-reporter-monorepo/pull/207)

# Dependency
N/A
