### PR TITLE
fix(frontend): AggregateError `ETIMEDOUT`

### DIFF
--- a/packages/frontend/CHANGELOG.md
+++ b/packages/frontend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.0.3-beta.3, 2025-04-09
+
+### Notable Changes
+
+- fix
+  - fix AggregateError `ETIMEDOUT` when fetching data
+
+### Commits
+
+- [[`ffd48a9fc1`](https://github.com/twreporter/congress-dashboard-monorepo/commit/ffd48a9fc1)] - **fix(frontend)**: AggregateError `ETIMEDOUT` (Aylie Chou)
+
 ## 0.0.3-beta.2, 2025-04-09
 
 ### Notable Changes

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -14,4 +14,6 @@ RUN yarn build
 
 ENV NODE_ENV=production
 
+ENV NODE_OPTIONS="--network-family-autoselection-attempt-timeout=500"
+
 CMD ["yarn", "start"]

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/congress-dashboard-frontend",
-  "version": "0.0.3-beta.2",
+  "version": "0.0.3-beta.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
# Issue
- fix fetch issue
  - https://github.com/nodejs/undici/issues/2777#issuecomment-2566924362
<img width="581" alt="截圖 2025-04-09 凌晨2 41 10" src="https://github.com/user-attachments/assets/8beefbb7-d31f-4218-a9ad-44d9ebfceba9" />

# Dependency
N/A
