### PR TITLE
chore: fix yarn.lock

### DIFF
--- a/packages/cms/CHANGELOG.md
+++ b/packages/cms/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.0.3-beta.2, 2025-04-16
+
+### Notable Changes
+
+- chore
+  - fix `yarn.lock` to use npm version @twreporter/shared
+
+### Commits
+
+- [[`8ab178ccf7`](https://github.com/twreporter/congress-dashboard-monorepo/commit/8ab178ccf7)] - **chore**: fix `yarn.lock` (Aylie Chou)
+
 ## 0.0.3-beta.1, 2025-04-08
 
 ### Notable Changes

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/congress-dashboard-cms",
-  "version": "0.0.3-beta.1",
+  "version": "0.0.3-beta.2",
   "private": true,
   "scripts": {
     "dev": "keystone dev",

--- a/packages/frontend/CHANGELOG.md
+++ b/packages/frontend/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
-## 0.0.3, 2024-05-23
+## 0.0.4-beta.0, 2025-04-16
+
+### Notable Changes
+
+- chore
+  - fix `yarn.lock` to use npm version @twreporter/shared
+
+### Commits
+
+- [[`8ab178ccf7`](https://github.com/twreporter/congress-dashboard-monorepo/commit/8ab178ccf7)] - **chore**: fix `yarn.lock` (Aylie Chou)
+
+## 0.0.3, 2025-04-16
 
 ### Notable Changes
 

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/congress-dashboard-frontend",
-  "version": "0.0.3",
+  "version": "0.0.4-beta.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6291,7 +6291,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@twreporter/congress-dashboard-shared@npm:0.0.3, @twreporter/congress-dashboard-shared@workspace:packages/shared":
+"@twreporter/congress-dashboard-shared@npm:0.0.3":
+  version: 0.0.3
+  resolution: "@twreporter/congress-dashboard-shared@npm:0.0.3"
+  checksum: 10c0/5e4e365d247f39142e33ff0028b341634111fe4255a476a45e5c94fdfc8d0a6f48c7c20125dd0a2cbea02769e9607b0b2defe2a2baad18bc3f04f17d8bdfc065
+  languageName: node
+  linkType: hard
+
+"@twreporter/congress-dashboard-shared@workspace:packages/shared":
   version: 0.0.0-use.local
   resolution: "@twreporter/congress-dashboard-shared@workspace:packages/shared"
   dependencies:


### PR DESCRIPTION
# Issue
- use npm version @twreporter/congress-dashboard-shared in `frontend` & `cms`
- fix cloud build failed([log](https://console.cloud.google.com/cloud-build/builds;region=asia-east1/2a7e8bf0-ec03-437b-be3d-8447dd53ab45?project=coastal-run-106202))

# Dependency
N/A
