### PR TITLE
fix(cms): set env to development for yarn install at Dockerfile

### DIFF
--- a/packages/cms/CHANGELOG.md
+++ b/packages/cms/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.0.3-beta.5, 2025-04-21
+
+### Notable Changes
+
+- fix
+  - install all dependencies for docker image
+
+### Commits
+
+- [[`40389475bc`](https://github.com/twreporter/congress-dashboard-monorepo/commit/40389475bc)] - **fix(cms)**: set env to development for yarn install at Dockerfile (Lucien)
+
 ## 0.0.3-beta.4, 2025-04-21
 
 ### Notable Changes

--- a/packages/cms/Dockerfile
+++ b/packages/cms/Dockerfile
@@ -34,7 +34,9 @@ WORKDIR $APP_DIR
 COPY . $APP_DIR
 
 ## Install application dependencies
-RUN yarn install
+## Force NODE_ENV to development to ensure devDependencies (like tsup for shared package build) are installed
+## Use --frozen-lockfile for reproducible builds based on yarn.lock
+RUN NODE_ENV=development yarn install --frozen-lockfile
 
 ## Build application bundles
 RUN yarn build

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/congress-dashboard-cms",
-  "version": "0.0.3-beta.4",
+  "version": "0.0.3-beta.5",
   "private": true,
   "scripts": {
     "dev": "keystone dev",


### PR DESCRIPTION
# Issue
[build fail](https://console.cloud.google.com/cloud-build/builds;region=asia-east1/3cf5da95-744d-4308-86a0-9c88845afb42;step=1?project=coastal-run-106202)

# Notice
<!-- Related notice or note for this PR -->

# Dependency
<!-- Related dependency of this PR -->
