### PR TITLE
refactor(frontend): update header search bar

### DIFF
--- a/packages/frontend/src/components/header/index.tsx
+++ b/packages/frontend/src/components/header/index.tsx
@@ -20,7 +20,10 @@ import {
 import { Hamburger, Cross } from '@twreporter/react-components/lib/icon'
 import { DEFAULT_SCREEN } from '@twreporter/core/lib/utils/media-query'
 import { Search as SearchIcon } from '@twreporter/react-components/lib/icon'
-import { SearchBar } from '@twreporter/react-components/lib/input'
+import {
+  AlgoliaInstantSearch,
+  layoutVariants,
+} from '@/components/search/instant-search'
 import useOutsideClick from '@twreporter/react-components/lib/hook/use-outside-click'
 // components
 import HamburgerMenu from '@/components/hamburger-menu'
@@ -125,12 +128,17 @@ const BtnContainer = styled.div<{
 const SearchContainer = styled.div<{
   $isOpen: boolean
 }>`
+  width: 360px;
+
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
   opacity: ${(props) => (props.$isOpen ? '1' : '0')};
   transition: opacity 300ms ease;
   position: absolute;
   right: 0;
   top: -8px;
-  z-index: ${(props) => (props.$isOpen ? 999 : -1)};
 `
 
 // Constants
@@ -181,10 +189,6 @@ const Header: React.FC = () => {
     if (input) {
       input.focus()
     }
-  }
-  const onSearch = (keywords: string) => {
-    setIsSearchOpen(false)
-    alert(`search: ${keywords}`)
   }
   const ref = useOutsideClick(closeSearchBox)
 
@@ -245,12 +249,15 @@ const Header: React.FC = () => {
                   />
                 </BtnContainer>
                 <SearchContainer $isOpen={isSearchOpen}>
-                  <SearchBar
-                    placeholder="關鍵字搜尋"
-                    theme={SearchBar.THEME.normal}
-                    onClose={closeSearchBox}
-                    onSearch={onSearch}
-                  />
+                  {isSearchOpen && (
+                    <>
+                      <AlgoliaInstantSearch variant={layoutVariants.Header} />
+                      <IconButton
+                        iconComponent={crossIcon}
+                        onClick={closeSearchBox}
+                      />
+                    </>
+                  )}
                 </SearchContainer>
               </SearchBox>
             </ButtonContainer>

--- a/packages/frontend/src/components/header/index.tsx
+++ b/packages/frontend/src/components/header/index.tsx
@@ -22,7 +22,7 @@ import { DEFAULT_SCREEN } from '@twreporter/core/lib/utils/media-query'
 import { Search as SearchIcon } from '@twreporter/react-components/lib/icon'
 import {
   AlgoliaInstantSearch,
-  layoutVariants,
+  LayoutVariants,
 } from '@/components/search/instant-search'
 // components
 import HamburgerMenu from '@/components/hamburger-menu'
@@ -242,7 +242,7 @@ const Header: React.FC = () => {
                   {isSearchOpen && (
                     <>
                       <AlgoliaInstantSearch
-                        variant={layoutVariants.Header}
+                        variant={LayoutVariants.Header}
                         autoFocus={isSearchOpen}
                       />
                       <IconButton

--- a/packages/frontend/src/components/header/index.tsx
+++ b/packages/frontend/src/components/header/index.tsx
@@ -24,7 +24,6 @@ import {
   AlgoliaInstantSearch,
   layoutVariants,
 } from '@/components/search/instant-search'
-import useOutsideClick from '@twreporter/react-components/lib/hook/use-outside-click'
 // components
 import HamburgerMenu from '@/components/hamburger-menu'
 // hooks
@@ -129,7 +128,6 @@ const SearchContainer = styled.div<{
   $isOpen: boolean
 }>`
   width: 360px;
-
   display: flex;
   align-items: center;
   gap: 8px;
@@ -182,15 +180,7 @@ const Header: React.FC = () => {
   const handleClickSearch = (e: React.MouseEvent) => {
     e.preventDefault()
     setIsSearchOpen(true)
-    if (!ref.current) {
-      return
-    }
-    const input = ref.current.getElementsByTagName('INPUT')[0]
-    if (input) {
-      input.focus()
-    }
   }
-  const ref = useOutsideClick(closeSearchBox)
 
   return (
     <React.Fragment>
@@ -238,7 +228,7 @@ const Header: React.FC = () => {
                   ) : null}
                 </React.Fragment>
               ))}
-              <SearchBox ref={ref} key="search">
+              <SearchBox key="search">
                 <BtnContainer
                   onClick={handleClickSearch}
                   $isOpen={isSearchOpen}
@@ -251,7 +241,10 @@ const Header: React.FC = () => {
                 <SearchContainer $isOpen={isSearchOpen}>
                   {isSearchOpen && (
                     <>
-                      <AlgoliaInstantSearch variant={layoutVariants.Header} />
+                      <AlgoliaInstantSearch
+                        variant={layoutVariants.Header}
+                        autoFocus={isSearchOpen}
+                      />
                       <IconButton
                         iconComponent={crossIcon}
                         onClick={closeSearchBox}

--- a/packages/frontend/src/components/open/index.tsx
+++ b/packages/frontend/src/components/open/index.tsx
@@ -76,6 +76,20 @@ const StyledSelected = styled(Selected)`
   `}
 `
 
+const InstantSearchContainer = styled.div`
+  ${mq.desktopAndAbove`
+    width: 560px;
+  `}
+
+  ${mq.tabletOnly`
+    width: 480px;
+  `}
+
+  ${mq.mobileOnly`
+    width: 327px;
+  `}
+`
+
 const Open: React.FC = () => {
   const descriptJSX = description.map((text, index) => (
     <SerifH4 text={text} key={`open-desc-${index}`} />
@@ -87,7 +101,9 @@ const Open: React.FC = () => {
       <MobileDescription>
         <SerifH4 text={description} />
       </MobileDescription>
-      <AlgoliaInstantSearch />
+      <InstantSearchContainer>
+        <AlgoliaInstantSearch />
+      </InstantSearchContainer>
       <StyledSelected />
     </Box>
   )

--- a/packages/frontend/src/components/search/instant-hits.tsx
+++ b/packages/frontend/src/components/search/instant-hits.tsx
@@ -36,6 +36,7 @@ const Container = styled.div`
   background-color: ${colorGrayscale.white};
   border-radius: 8px;
   padding: 8px 0;
+  margin-top: 8px;
   box-shadow: 0px 0px 24px 0px ${colorOpacity['black_0.1']};
 
   a {

--- a/packages/frontend/src/components/search/instant-search.tsx
+++ b/packages/frontend/src/components/search/instant-search.tsx
@@ -5,7 +5,7 @@ import {
   defaultIndexName,
 } from '@/components/search/instant-hits'
 import { InstantSearch, useSearchBox } from 'react-instantsearch'
-import { SearchBox, layoutVariants } from '@/components/search/search-box'
+import { SearchBox, LayoutVariants } from '@/components/search/search-box'
 import type { LayoutVariant } from '@/components/search/search-box'
 import { ZIndex } from '@/styles/z-index'
 import { liteClient as algoliasearch } from 'algoliasearch/lite'
@@ -21,7 +21,7 @@ const searchClient = algoliasearch(
   algoliaConfig.searchAPIKey
 )
 
-export { layoutVariants }
+export { LayoutVariants }
 
 const Container = styled.div<{ $variant: LayoutVariant }>`
   /* TODO: remove box-sizing if global already defined */
@@ -33,7 +33,7 @@ const Container = styled.div<{ $variant: LayoutVariant }>`
 
   ${({ $variant }) => {
     // Set the z-index to avoid covering the header and being covered by the sticky bar.
-    if ($variant === layoutVariants.Default) {
+    if ($variant === LayoutVariants.Default) {
       return `z-index: ${ZIndex.SearchBarInBody};`
     }
   }}
@@ -75,7 +75,7 @@ const ClickOutsideWidget = ({ containerRef }) => {
 
 export const AlgoliaInstantSearch = ({
   className,
-  variant = layoutVariants.Default,
+  variant = LayoutVariants.Default,
   autoFocus = false,
 }: {
   className?: string

--- a/packages/frontend/src/components/search/instant-search.tsx
+++ b/packages/frontend/src/components/search/instant-search.tsx
@@ -50,14 +50,16 @@ const InstantHits = styled(_InstantHits)`
 export const AlgoliaInstantSearch = ({
   className,
   variant = layoutVariants.Default,
+  autoFocus = false,
 }: {
   className?: string
   variant?: LayoutVariant
+  autoFocus?: boolean
 }) => {
   return (
     <Container className={className} $variant={variant}>
       <InstantSearch indexName={defaultIndexName} searchClient={searchClient}>
-        <SearchBox variant={variant} />
+        <SearchBox variant={variant} autoFocus={autoFocus} />
         <InstantHits />
       </InstantSearch>
     </Container>

--- a/packages/frontend/src/components/search/instant-search.tsx
+++ b/packages/frontend/src/components/search/instant-search.tsx
@@ -5,7 +5,8 @@ import {
   defaultIndexName,
 } from '@/components/search/instant-hits'
 import { InstantSearch } from 'react-instantsearch'
-import { SearchBox } from '@/components/search/search-box'
+import { SearchBox, layoutVariants } from '@/components/search/search-box'
+import type { LayoutVariant } from '@/components/search/search-box'
 import { ZIndex } from '@/styles/z-index'
 import { liteClient as algoliasearch } from 'algoliasearch/lite'
 
@@ -20,13 +21,22 @@ const searchClient = algoliasearch(
   algoliaConfig.searchAPIKey
 )
 
-const Container = styled.div`
+export { layoutVariants }
+
+const Container = styled.div<{ $variant: LayoutVariant }>`
   /* TODO: remove box-sizing if global already defined */
   * {
     box-sizing: border-box;
   }
 
   position: relative;
+
+  ${({ $variant }) => {
+    // Set the z-index to avoid covering the header and being covered by the sticky bar.
+    if ($variant === layoutVariants.Default) {
+      return `z-index: ${ZIndex.SearchBarInBody};`
+    }
+  }}
 
   width: 100%;
 
@@ -35,14 +45,19 @@ const Container = styled.div`
 
 const InstantHits = styled(_InstantHits)`
   position: absolute;
-  z-index: ${ZIndex.SearchBar};
 `
 
-export const AlgoliaInstantSearch = ({ className }: { className?: string }) => {
+export const AlgoliaInstantSearch = ({
+  className,
+  variant = layoutVariants.Default,
+}: {
+  className?: string
+  variant?: LayoutVariant
+}) => {
   return (
-    <Container className={className}>
+    <Container className={className} $variant={variant}>
       <InstantSearch indexName={defaultIndexName} searchClient={searchClient}>
-        <SearchBox />
+        <SearchBox variant={variant} />
         <InstantHits />
       </InstantSearch>
     </Container>

--- a/packages/frontend/src/components/search/instant-search.tsx
+++ b/packages/frontend/src/components/search/instant-search.tsx
@@ -1,10 +1,10 @@
-import React from 'react'
+import React, { useEffect, useRef } from 'react'
 import styled from 'styled-components'
 import {
   InstantHits as _InstantHits,
   defaultIndexName,
 } from '@/components/search/instant-hits'
-import { InstantSearch } from 'react-instantsearch'
+import { InstantSearch, useSearchBox } from 'react-instantsearch'
 import { SearchBox, layoutVariants } from '@/components/search/search-box'
 import type { LayoutVariant } from '@/components/search/search-box'
 import { ZIndex } from '@/styles/z-index'
@@ -47,6 +47,32 @@ const InstantHits = styled(_InstantHits)`
   position: absolute;
 `
 
+const ClickOutsideWidget = ({ containerRef }) => {
+  const { query, refine } = useSearchBox()
+
+  useEffect(() => {
+    if (query === '') {
+      return
+    }
+
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        refine('')
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+    }
+  }, [containerRef, query])
+
+  return null
+}
+
 export const AlgoliaInstantSearch = ({
   className,
   variant = layoutVariants.Default,
@@ -56,11 +82,13 @@ export const AlgoliaInstantSearch = ({
   variant?: LayoutVariant
   autoFocus?: boolean
 }) => {
+  const containerRef = useRef(null)
   return (
-    <Container className={className} $variant={variant}>
+    <Container ref={containerRef} className={className} $variant={variant}>
       <InstantSearch indexName={defaultIndexName} searchClient={searchClient}>
         <SearchBox variant={variant} autoFocus={autoFocus} />
         <InstantHits />
+        <ClickOutsideWidget containerRef={containerRef} />
       </InstantSearch>
     </Container>
   )

--- a/packages/frontend/src/components/search/instant-search.tsx
+++ b/packages/frontend/src/components/search/instant-search.tsx
@@ -28,8 +28,7 @@ const Container = styled.div`
 
   position: relative;
 
-  /* desktop styles */
-  width: 560px;
+  width: 100%;
 
   /* TODO: add mobile styles */
 `
@@ -39,9 +38,9 @@ const InstantHits = styled(_InstantHits)`
   z-index: ${ZIndex.SearchBar};
 `
 
-export const AlgoliaInstantSearch = () => {
+export const AlgoliaInstantSearch = ({ className }: { className?: string }) => {
   return (
-    <Container>
+    <Container className={className}>
       <InstantSearch indexName={defaultIndexName} searchClient={searchClient}>
         <SearchBox />
         <InstantHits />

--- a/packages/frontend/src/components/search/search-box.tsx
+++ b/packages/frontend/src/components/search/search-box.tsx
@@ -9,19 +9,19 @@ const _ = {
   debounce,
 }
 
-export const layoutVariants = {
+export const LayoutVariants = {
   Default: 'default', // search bar in the body of the page
   Header: 'header', // search bar in the header
 } as const
 
-export type LayoutVariant = (typeof layoutVariants)[keyof typeof layoutVariants]
+export type LayoutVariant = (typeof LayoutVariants)[keyof typeof LayoutVariants]
 
 const Container = styled.div<{ $variant: LayoutVariant }>`
   width: 100%;
   background-color: ${colorGrayscale.white};
 
   ${({ $variant }) => {
-    if ($variant === layoutVariants.Header) {
+    if ($variant === LayoutVariants.Header) {
       return `
         padding: 8px 20px;
         height: 40px;

--- a/packages/frontend/src/components/search/search-box.tsx
+++ b/packages/frontend/src/components/search/search-box.tsx
@@ -91,6 +91,10 @@ export const SearchBox = ({
     }
   }, [autoFocus])
 
+  useEffect(() => {
+    setInputValue(query)
+  }, [query])
+
   return (
     <Container className={className} $variant={variant}>
       <IconSearch />

--- a/packages/frontend/src/components/search/search-box.tsx
+++ b/packages/frontend/src/components/search/search-box.tsx
@@ -1,20 +1,37 @@
-import React, { useState, useMemo } from 'react'
-import { useSearchBox } from 'react-instantsearch'
+import React, { useRef, useState, useMemo } from 'react'
+import debounce from 'lodash/debounce'
 import styled from 'styled-components'
 import { Search as IconSearch, X as IconX } from '@/components/search/icons'
-import debounce from 'lodash/debounce'
 import { colorGrayscale } from '@twreporter/core/lib/constants/color'
+import { useSearchBox } from 'react-instantsearch'
 
 const _ = {
   debounce,
 }
 
-const Container = styled.div`
+export const layoutVariants = {
+  Default: 'default', // search bar in the body of the page
+  Header: 'header', // search bar in the header
+} as const
+
+export type LayoutVariant = (typeof layoutVariants)[keyof typeof layoutVariants]
+
+const Container = styled.div<{ $variant: LayoutVariant }>`
   width: 100%;
   background-color: ${colorGrayscale.white};
 
-  margin-bottom: 8px;
-  padding: 12px 20px;
+  ${({ $variant }) => {
+    if ($variant === layoutVariants.Header) {
+      return `
+        padding: 8px 20px;
+        height: 40px;
+      `
+    }
+    return `
+      padding: 12px 20px;
+      height: 48px;
+    `
+  }}
 
   display: flex;
   align-items: center;
@@ -43,7 +60,14 @@ const ClearButton = styled.button`
   line-height: 0;
 `
 
-export const SearchBox = () => {
+export const SearchBox = ({
+  className,
+  variant,
+}: {
+  className?: string
+  variant: LayoutVariant
+}) => {
+  const inputRef = useRef<HTMLInputElement>(null)
   const { query, refine: _refine } = useSearchBox()
   const [inputValue, setInputValue] = useState(query)
   const refine = useMemo(() => _.debounce(_refine, 500), [_refine])
@@ -60,13 +84,14 @@ export const SearchBox = () => {
   }
 
   return (
-    <Container>
+    <Container className={className} $variant={variant}>
       <IconSearch />
       <Input
+        ref={inputRef}
         type="text"
         value={inputValue}
         onChange={handleOnChange}
-        placeholder="搜尋立委、議題和逐字稿..."
+        placeholder="搜尋立委和議題"
       />
       {inputValue && (
         <ClearButton onClick={clearQuery}>

--- a/packages/frontend/src/components/search/search-box.tsx
+++ b/packages/frontend/src/components/search/search-box.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState, useMemo } from 'react'
+import React, { useEffect, useRef, useState, useMemo } from 'react'
 import debounce from 'lodash/debounce'
 import styled from 'styled-components'
 import { Search as IconSearch, X as IconX } from '@/components/search/icons'
@@ -63,9 +63,11 @@ const ClearButton = styled.button`
 export const SearchBox = ({
   className,
   variant,
+  autoFocus,
 }: {
   className?: string
   variant: LayoutVariant
+  autoFocus: boolean
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const { query, refine: _refine } = useSearchBox()
@@ -82,6 +84,12 @@ export const SearchBox = ({
     setInputValue('')
     refine('')
   }
+
+  useEffect(() => {
+    if (autoFocus) {
+      inputRef.current?.focus()
+    }
+  }, [autoFocus])
 
   return (
     <Container className={className} $variant={variant}>

--- a/packages/frontend/src/styles/z-index.ts
+++ b/packages/frontend/src/styles/z-index.ts
@@ -1,8 +1,8 @@
 export enum ZIndex {
   ControlBar = 900,
   Header = 1000,
-  Bar = Header,
-  SearchBar = 1010,
+  SearchBarInBody = Header - 1,
+  Bar = SearchBarInBody - 1,
   HamburgerMenu = 1100,
   FilterModal = 1200,
   SideBar = 3000,


### PR DESCRIPTION
### 前言
此 PR 是奠基在 https://github.com/twreporter/congress-dashboard-monorepo/pull/87 之上，所以重複的 commits 可以忽略不看，只需要看最新的三個 commits：
- [style(frontend): update width of search bar](https://github.com/twreporter/congress-dashboard-monorepo/commit/a1fcfa8f68fbc8e3a28e34370224d33183dd8ebc)
- [refactor(frontend): update header. Replace SearchBar by AlgoliaInstanSearch](https://github.com/twreporter/congress-dashboard-monorepo/commit/96c60862ba06762951025e1cc6c4402b5a5efb0c)
- [refactor(frontend): update header search. Auto focus when search bar is open](https://github.com/twreporter/congress-dashboard-monorepo/commit/2e5689761f8b2c19cff20eb8ae36f22c0dea59ce) 
- [refactor(frontend): update search. Reset query if click outside](https://github.com/twreporter/congress-dashboard-monorepo/pull/89/commits/95152d7d2103a880f1b9bd31f69ed5c78ed9685b)


### 實作說明
因為 header 裡的 search bar 與頁面中間的 search bar 有些許的不同，所以我新增 `variant` prop 來決定要呈現哪一個版本的 search bar。
此外，也新增 `autoFocus` prop 來實作「點擊 search icon 後，展開 search bar 後，滑鼠會自動 focus 在輸入框中」。
最後，將 click outside 的實作搬到 `<AlgoliaInstantSearch>` 中，當使用者點擊 search bar 以外的地方時，會將 query 清空。
