### PR TITLE
fix(cms): set default sort to id for import record

### DIFF
--- a/packages/cms/CHANGELOG.md
+++ b/packages/cms/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.0.0-rc.3, 2025-05-06
+
+### Notable Changes
+
+- fix
+  - set default sort to id for import record
+
+### Commits
+
+- [[`64c898ce72`](https://github.com/twreporter/congress-dashboard-monorepo/commit/64c898ce72)] - **fix(cms)**: set default sort to id for import record (Lucien)
+
 ## 1.0.0-rc.2, 2025-05-05
 
 ### Notable Changes

--- a/packages/cms/lists/Committee.ts
+++ b/packages/cms/lists/Committee.ts
@@ -29,8 +29,8 @@ const listConfigurations = list({
       ],
       isIndexed: true,
     }),
-    createdAt: CREATED_AT,
-    updatedAt: UPDATED_AT,
+    createdAt: CREATED_AT(),
+    updatedAt: UPDATED_AT(),
   },
   ui: {
     label: '委員會',

--- a/packages/cms/lists/CommitteeMember.ts
+++ b/packages/cms/lists/CommitteeMember.ts
@@ -32,8 +32,8 @@ const listConfigurations = list({
         labelField: 'name',
       },
     }),
-    createdAt: CREATED_AT,
-    updatedAt: UPDATED_AT,
+    createdAt: CREATED_AT(),
+    updatedAt: UPDATED_AT(),
   },
   ui: {
     label: '委員會屆資',

--- a/packages/cms/lists/ImportRecord.ts
+++ b/packages/cms/lists/ImportRecord.ts
@@ -791,6 +791,7 @@ const listConfigurations = list({
       label: '紀錄名稱',
       validation: { isRequired: true },
       ui: { itemView: { fieldMode: 'edit' } },
+      isOrderable: false,
     }),
     uploadData: uploader({
       label: '上傳資料',
@@ -804,8 +805,8 @@ const listConfigurations = list({
         createView: { fieldMode: 'hidden' },
       },
     }),
-    createdAt: CREATED_AT,
-    updatedAt: UPDATED_AT,
+    createdAt: CREATED_AT({ isOrderable: false }),
+    updatedAt: UPDATED_AT({ isOrderable: false }),
   },
 
   ui: {
@@ -813,7 +814,7 @@ const listConfigurations = list({
     labelField: 'recordName',
     listView: {
       initialColumns: ['recordName', 'uploadData', 'createdAt', 'updatedAt'],
-      initialSort: { field: 'createdAt', direction: 'DESC' },
+      initialSort: { field: 'id', direction: 'DESC' },
       pageSize: 50,
     },
     hideDelete: ({ session }) => {
@@ -840,7 +841,7 @@ const listConfigurations = list({
     resolveInput: {
       create: ({ resolvedData, context }) => {
         const { session } = context
-        resolvedData.importer = { connect: { id: session.itemId } }
+        resolvedData.importer = { connect: { id: Number(session.itemId) } }
         return resolvedData
       },
     },

--- a/packages/cms/lists/LegislativeMeeting.ts
+++ b/packages/cms/lists/LegislativeMeeting.ts
@@ -35,8 +35,8 @@ const listConfigurations = list({
       label: '委員會',
       many: true,
     }),
-    createdAt: CREATED_AT,
-    updatedAt: UPDATED_AT,
+    createdAt: CREATED_AT(),
+    updatedAt: UPDATED_AT(),
   },
   ui: {
     label: '立法院屆期',

--- a/packages/cms/lists/LegislativeMeetingSession.ts
+++ b/packages/cms/lists/LegislativeMeetingSession.ts
@@ -78,8 +78,8 @@ const listConfigurations = list({
         isRequired: true,
       },
     }),
-    createdAt: CREATED_AT,
-    updatedAt: UPDATED_AT,
+    createdAt: CREATED_AT(),
+    updatedAt: UPDATED_AT(),
   },
   ui: {
     label: '立法院會期',

--- a/packages/cms/lists/LegislativeYuanMember.ts
+++ b/packages/cms/lists/LegislativeYuanMember.ts
@@ -127,8 +127,8 @@ const listConfigurations = list({
     proposalSuccessCount: integer({
       label: '提案通過數',
     }),
-    createdAt: CREATED_AT,
-    updatedAt: UPDATED_AT,
+    createdAt: CREATED_AT(),
+    updatedAt: UPDATED_AT(),
   },
   ui: {
     label: '立委屆資',

--- a/packages/cms/lists/Legislator.ts
+++ b/packages/cms/lists/Legislator.ts
@@ -38,8 +38,8 @@ const listConfigurations = list({
     meetingTermCountInfo: text({
       label: '立委任期屆數說明',
     }),
-    createdAt: CREATED_AT,
-    updatedAt: UPDATED_AT,
+    createdAt: CREATED_AT(),
+    updatedAt: UPDATED_AT(),
   },
   ui: {
     label: '立法委員',

--- a/packages/cms/lists/Party.ts
+++ b/packages/cms/lists/Party.ts
@@ -22,8 +22,8 @@ const listConfigurations = list({
     imageLink: text({
       label: 'ImageLink',
     }),
-    createdAt: CREATED_AT,
-    updatedAt: UPDATED_AT,
+    createdAt: CREATED_AT(),
+    updatedAt: UPDATED_AT(),
   },
   ui: {
     label: '政黨',

--- a/packages/cms/lists/Photo.ts
+++ b/packages/cms/lists/Photo.ts
@@ -18,8 +18,8 @@ const listConfigurations = list({
     imageFile: image({
       storage: 'images',
     }),
-    createdAt: CREATED_AT,
-    updatedAt: UPDATED_AT,
+    createdAt: CREATED_AT(),
+    updatedAt: UPDATED_AT(),
   },
   ui: {
     label: 'Photos',

--- a/packages/cms/lists/Selected.ts
+++ b/packages/cms/lists/Selected.ts
@@ -65,8 +65,8 @@ const listConfigurations = list({
         },
       },
     }),
-    createdAt: CREATED_AT,
-    updatedAt: UPDATED_AT,
+    createdAt: CREATED_AT(),
+    updatedAt: UPDATED_AT(),
   },
   ui: {
     label: '編輯精選',

--- a/packages/cms/lists/Speech.ts
+++ b/packages/cms/lists/Speech.ts
@@ -71,8 +71,8 @@ const listConfigurations = list({
         labelField: 'title',
       },
     }),
-    createdAt: CREATED_AT,
-    updatedAt: UPDATED_AT,
+    createdAt: CREATED_AT(),
+    updatedAt: UPDATED_AT(),
   },
   ui: {
     label: '逐字稿',

--- a/packages/cms/lists/SystemUser.ts
+++ b/packages/cms/lists/SystemUser.ts
@@ -46,8 +46,8 @@ const listConfigurations = list({
       ],
       validation: { isRequired: true },
     }),
-    createdAt: CREATED_AT,
-    updatedAt: UPDATED_AT,
+    createdAt: CREATED_AT(),
+    updatedAt: UPDATED_AT(),
   },
   ui: {
     isHidden: ({ session }) => {

--- a/packages/cms/lists/Topic.ts
+++ b/packages/cms/lists/Topic.ts
@@ -50,8 +50,8 @@ const listConfigurations = list({
         views: './lists/views/related-article',
       },
     }),
-    createdAt: CREATED_AT,
-    updatedAt: UPDATED_AT,
+    createdAt: CREATED_AT(),
+    updatedAt: UPDATED_AT(),
   },
   ui: {
     label: '議題',

--- a/packages/cms/lists/utils/common-field.ts
+++ b/packages/cms/lists/utils/common-field.ts
@@ -1,4 +1,9 @@
-import { text, timestamp } from '@keystone-6/core/fields'
+import {
+  text,
+  timestamp,
+  type TimestampFieldConfig,
+} from '@keystone-6/core/fields'
+import { type BaseListTypeInfo } from '@keystone-6/core/types'
 
 // ref: https://regex101.com/r/gilHCG/1
 export const URL_VALIDATION_REGEX =
@@ -16,20 +21,24 @@ export const SLUG = text({
   isIndexed: 'unique',
 })
 
-export const CREATED_AT = timestamp({
-  defaultValue: { kind: 'now' },
-  ui: {
-    createView: { fieldMode: 'hidden' },
-    itemView: { fieldMode: 'read' },
-  },
-})
+export const CREATED_AT = (opts: TimestampFieldConfig<BaseListTypeInfo> = {}) =>
+  timestamp({
+    defaultValue: { kind: 'now' },
+    ui: {
+      createView: { fieldMode: 'hidden' },
+      itemView: { fieldMode: 'read' },
+    },
+    ...opts,
+  })
 
-export const UPDATED_AT = timestamp({
-  db: {
-    updatedAt: true,
-  },
-  ui: {
-    createView: { fieldMode: 'hidden' },
-    itemView: { fieldMode: 'read' },
-  },
-})
+export const UPDATED_AT = (opts: TimestampFieldConfig<BaseListTypeInfo> = {}) =>
+  timestamp({
+    db: {
+      updatedAt: true,
+    },
+    ui: {
+      createView: { fieldMode: 'hidden' },
+      itemView: { fieldMode: 'read' },
+    },
+    ...opts,
+  })

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/congress-dashboard-cms",
-  "version": "1.0.0-rc.2",
+  "version": "1.0.0-rc.3",
   "private": true,
   "scripts": {
     "dev": "keystone dev",

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -1132,9 +1132,6 @@ enum ListNameEnum {
 
 input ImportRecordOrderByInput {
   id: OrderDirection
-  recordName: OrderDirection
-  createdAt: OrderDirection
-  updatedAt: OrderDirection
 }
 
 input ImportRecordUpdateInput {


### PR DESCRIPTION
# Issue
Fix import record prisma error by setting sort option to id.

# Notice
Prisma Error Message:
```
Error occurred during query execution:
ConnectorError(ConnectorError { user_facing_error: None, kind: QueryError(Server(MysqlError { code: 1038, message: "Out of sort memory, consider increasing server sort buffer size", state: "HY001" })), transient: false }
```

# Dependency
<!-- Related dependency of this PR -->
