### PR TITLE
refactor(frontend): mobile search modal

### DIFF
--- a/packages/frontend/src/components/header/index.tsx
+++ b/packages/frontend/src/components/header/index.tsx
@@ -28,6 +28,7 @@ import {
 import HamburgerMenu from '@/components/hamburger-menu'
 // hooks
 import useWindowWidth from '@/hooks/use-window-width'
+import { useScrollLock } from '@/hooks/use-scroll-lock'
 // z-index
 import { ZIndex } from '@/styles/z-index'
 // constants
@@ -154,23 +155,14 @@ const Header: React.FC = () => {
     setIsHamburgerOpen((prev) => !prev)
   }, [])
 
+  // Handle body scroll lock
+  useScrollLock(isHamburgerOpen)
+
   useEffect(() => {
     if (windowWidth >= DEFAULT_SCREEN.tablet.minWidth) {
       setIsHamburgerOpen(false)
     }
   }, [windowWidth])
-
-  // Handle body scroll lock
-  useEffect(() => {
-    if (isHamburgerOpen) {
-      document.body.style.overflow = 'hidden'
-    } else {
-      document.body.style.overflow = 'unset'
-    }
-    return () => {
-      document.body.style.overflow = 'unset'
-    }
-  }, [isHamburgerOpen])
 
   // search functions
   const [isSearchOpen, setIsSearchOpen] = useState(false)

--- a/packages/frontend/src/components/open/index.tsx
+++ b/packages/frontend/src/components/open/index.tsx
@@ -86,7 +86,8 @@ const InstantSearchContainer = styled.div`
   `}
 
   ${mq.mobileOnly`
-    width: 327px;
+    width: 100%;
+    max-width: 480px;
   `}
 `
 

--- a/packages/frontend/src/components/search/constants.ts
+++ b/packages/frontend/src/components/search/constants.ts
@@ -1,0 +1,7 @@
+export const LayoutVariants = {
+  Default: 'default', // search bar in the body of the page
+  Header: 'header', // search bar in the header
+  Modal: 'modal', // search bar in the modal
+} as const
+
+export type LayoutVariant = (typeof LayoutVariants)[keyof typeof LayoutVariants]

--- a/packages/frontend/src/components/search/instant-hits.tsx
+++ b/packages/frontend/src/components/search/instant-hits.tsx
@@ -1,5 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react'
 import styled from 'styled-components'
+import type { LayoutVariant } from '@/components/search/constants'
+import { LayoutVariants } from '@/components/search/constants'
 import { useInView } from 'react-intersection-observer'
 import type {
   LegislatorRawHit,
@@ -29,16 +31,31 @@ const InstantSearchStatus = {
   Error: 'error',
 } as const
 
-const Container = styled.div`
+const Container = styled.div<{ $variant: LayoutVariant }>`
   width: 100%;
   max-height: 320px;
   overflow: scroll;
   background-color: ${colorGrayscale.white};
-  border-radius: 8px;
-  padding: 8px 0;
-  margin-top: 8px;
-  box-shadow: 0px 0px 24px 0px ${colorOpacity['black_0.1']};
 
+  ${({ $variant }) => {
+    switch ($variant) {
+      case LayoutVariants.Modal: {
+        return `
+          border-top: 1px solid ${colorGrayscale.gray300};
+        `
+      }
+      case LayoutVariants.Header:
+      case LayoutVariants.Default:
+      default: {
+        return `
+          border-radius: 8px;
+          padding: 8px 0;
+          margin-top: 8px;
+          box-shadow: 0px 0px 24px 0px ${colorOpacity['black_0.1']};
+        `
+      }
+    }
+  }}
   a {
     text-decoration: none;
   }
@@ -74,7 +91,9 @@ const SearchText = styled.div`
 `
 
 const Rows = styled.div`
-  border-top: 1px solid ${colorGrayscale.gray300};
+  &:not(:empty) {
+    border-top: 1px solid ${colorGrayscale.gray300};
+  }
 `
 
 // TODO: replace loading indicator after design ready
@@ -115,7 +134,13 @@ enum IndexNameEnum {
 
 export const defaultIndexName = IndexNameEnum.Legislator
 
-export const InstantHits = ({ className }: { className?: string }) => {
+export const InstantHits = ({
+  className,
+  variant = LayoutVariants.Default,
+}: {
+  className?: string
+  variant?: LayoutVariant
+}) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const { query } = useSearchBox()
   const [stage, setStage] = useState(SearchStageEnum.Legislator)
@@ -125,7 +150,7 @@ export const InstantHits = ({ className }: { className?: string }) => {
   }
 
   return (
-    <Container ref={containerRef} className={className}>
+    <Container ref={containerRef} className={className} $variant={variant}>
       {/* TODO: change to `next/link` when search page is ready */}
       <a href="" target="_self">
         <FirstRow>
@@ -266,7 +291,7 @@ const LoadMore = ({
     }
 
     load()
-  }, [query, inView, isLoading, renderState, stage, setStage])
+  }, [query, inView, isLoading, renderState, stage, setStage, noMoreHits])
 
   return (
     <div>

--- a/packages/frontend/src/components/search/instant-search.tsx
+++ b/packages/frontend/src/components/search/instant-search.tsx
@@ -1,12 +1,16 @@
 import React, { useEffect, useRef, useState } from 'react'
+import useWindowWidth from '@/hooks/use-window-width'
 import styled from 'styled-components'
+import type { LayoutVariant } from '@/components/search/constants'
+import { DEFAULT_SCREEN } from '@twreporter/core/lib/utils/media-query'
 import {
   InstantHits as _InstantHits,
   defaultIndexName,
 } from '@/components/search/instant-hits'
 import { InstantSearch, useSearchBox } from 'react-instantsearch'
-import { SearchBox, LayoutVariants } from '@/components/search/search-box'
-import type { LayoutVariant } from '@/components/search/search-box'
+import { LayoutVariants } from '@/components/search/constants'
+import { SearchBox } from '@/components/search/search-box'
+import { SearchModal } from '@/components/search/modal'
 import { ZIndex } from '@/styles/z-index'
 import { liteClient as algoliasearch } from 'algoliasearch/lite'
 
@@ -96,15 +100,34 @@ export const AlgoliaInstantSearch = ({
 }) => {
   const containerRef = useRef(null)
   const [focused, setFocused] = useState(true)
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const windowWidth = useWindowWidth()
+
+  if (isModalOpen) {
+    return (
+      <InstantSearch indexName={defaultIndexName} searchClient={searchClient}>
+        <SearchModal
+          onClose={() => {
+            setIsModalOpen(false)
+          }}
+        />
+      </InstantSearch>
+    )
+  }
 
   return (
-    <Container ref={containerRef} className={className} $variant={variant}>
-      <InstantSearch indexName={defaultIndexName} searchClient={searchClient}>
+    <InstantSearch indexName={defaultIndexName} searchClient={searchClient}>
+      <Container ref={containerRef} className={className} $variant={variant}>
         <SearchBox
           variant={variant}
           autoFocus={autoFocus}
           onFocus={() => {
             setFocused(true)
+
+            // For mobile, open the search modal
+            if (windowWidth < DEFAULT_SCREEN.tablet.minWidth) {
+              setIsModalOpen(true)
+            }
           }}
         />
         <InstantHits $hide={!focused} />
@@ -114,7 +137,7 @@ export const AlgoliaInstantSearch = ({
             setFocused(false)
           }}
         />
-      </InstantSearch>
-    </Container>
+      </Container>
+    </InstantSearch>
   )
 }

--- a/packages/frontend/src/components/search/instant-search.tsx
+++ b/packages/frontend/src/components/search/instant-search.tsx
@@ -48,7 +48,7 @@ const InstantHits = styled(_InstantHits)`
 `
 
 const ClickOutsideWidget = ({ containerRef }) => {
-  const { query, refine } = useSearchBox()
+  const { query, clear } = useSearchBox()
 
   useEffect(() => {
     if (query === '') {
@@ -60,7 +60,7 @@ const ClickOutsideWidget = ({ containerRef }) => {
         containerRef.current &&
         !containerRef.current.contains(event.target as Node)
       ) {
-        refine('')
+        clear()
       }
     }
 

--- a/packages/frontend/src/components/search/instant-search.tsx
+++ b/packages/frontend/src/components/search/instant-search.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import styled from 'styled-components'
 import {
   InstantHits as _InstantHits,
@@ -43,12 +43,24 @@ const Container = styled.div<{ $variant: LayoutVariant }>`
   /* TODO: add mobile styles */
 `
 
-const InstantHits = styled(_InstantHits)`
+const InstantHits = styled(_InstantHits)<{ $hide: boolean }>`
   position: absolute;
+  ${({ $hide }) => {
+    if ($hide) {
+      return `display: none;`
+    }
+    return `display: block;`
+  }}
 `
 
-const ClickOutsideWidget = ({ containerRef }) => {
-  const { query, clear } = useSearchBox()
+const ClickOutsideWidget = ({
+  containerRef,
+  onClickOutside,
+}: {
+  containerRef: React.RefObject<HTMLElement | null>
+  onClickOutside: () => void
+}) => {
+  const { query } = useSearchBox()
 
   useEffect(() => {
     if (query === '') {
@@ -60,7 +72,7 @@ const ClickOutsideWidget = ({ containerRef }) => {
         containerRef.current &&
         !containerRef.current.contains(event.target as Node)
       ) {
-        clear()
+        onClickOutside()
       }
     }
 
@@ -68,7 +80,7 @@ const ClickOutsideWidget = ({ containerRef }) => {
     return () => {
       document.removeEventListener('mousedown', handleClickOutside)
     }
-  }, [containerRef, query])
+  }, [containerRef, onClickOutside, query])
 
   return null
 }
@@ -83,12 +95,25 @@ export const AlgoliaInstantSearch = ({
   autoFocus?: boolean
 }) => {
   const containerRef = useRef(null)
+  const [focused, setFocused] = useState(true)
+
   return (
     <Container ref={containerRef} className={className} $variant={variant}>
       <InstantSearch indexName={defaultIndexName} searchClient={searchClient}>
-        <SearchBox variant={variant} autoFocus={autoFocus} />
-        <InstantHits />
-        <ClickOutsideWidget containerRef={containerRef} />
+        <SearchBox
+          variant={variant}
+          autoFocus={autoFocus}
+          onFocus={() => {
+            setFocused(true)
+          }}
+        />
+        <InstantHits $hide={!focused} />
+        <ClickOutsideWidget
+          containerRef={containerRef}
+          onClickOutside={() => {
+            setFocused(false)
+          }}
+        />
       </InstantSearch>
     </Container>
   )

--- a/packages/frontend/src/components/search/modal.tsx
+++ b/packages/frontend/src/components/search/modal.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import styled from 'styled-components'
+import { Cross } from '@twreporter/react-components/lib/icon'
+import { IconButton } from '@twreporter/react-components/lib/button'
+import { InstantHits } from '@/components/search/instant-hits'
+import { SearchBox } from '@/components/search/search-box'
+import { LayoutVariants } from '@/components/search/constants'
+import { ZIndex } from '@/styles/z-index'
+import { colorGrayscale } from '@twreporter/core/lib/constants/color'
+import { useScrollLock } from '@/hooks/use-scroll-lock'
+
+const releaseBranch = process.env.NEXT_PUBLIC_RELEASE_BRANCH
+
+const Overlay = styled.div`
+  position: fixed;
+  width: 100vw;
+  height: 100vh;
+  inset: 0;
+  background: ${colorGrayscale.white};
+  z-index: ${ZIndex.FilterModal};
+  overflow: auto;
+`
+
+const SearchBoxContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 28px;
+
+  padding: 12px 36px 12px 24px;
+`
+
+export const SearchModal = ({
+  className,
+  onClose,
+}: {
+  className?: string
+  onClose: () => void
+}) => {
+  // Lock body scroll
+  useScrollLock(true)
+
+  return ReactDOM.createPortal(
+    <Overlay className={className}>
+      <SearchBoxContainer>
+        <SearchBox variant={LayoutVariants.Modal} autoFocus={true} />
+        <IconButton
+          iconComponent={<Cross releaseBranch={releaseBranch} />}
+          onClick={onClose}
+        />
+      </SearchBoxContainer>
+      <InstantHits variant={LayoutVariants.Modal} />
+    </Overlay>,
+    // Append the modal to <body> to avoid z-index issues caused by parent stacking contexts
+    document.body
+  )
+}

--- a/packages/frontend/src/components/search/search-box.tsx
+++ b/packages/frontend/src/components/search/search-box.tsx
@@ -86,12 +86,6 @@ export const SearchBox = ({
   }
 
   useEffect(() => {
-    if (autoFocus) {
-      inputRef.current?.focus()
-    }
-  }, [autoFocus])
-
-  useEffect(() => {
     setInputValue(query)
   }, [query])
 
@@ -104,6 +98,7 @@ export const SearchBox = ({
         value={inputValue}
         onChange={handleOnChange}
         placeholder="搜尋立委和議題"
+        autoFocus={autoFocus}
       />
       {inputValue && (
         <ClearButton onClick={clearQuery}>

--- a/packages/frontend/src/components/search/search-box.tsx
+++ b/packages/frontend/src/components/search/search-box.tsx
@@ -1,6 +1,8 @@
 import React, { useEffect, useRef, useState, useMemo } from 'react'
 import debounce from 'lodash/debounce'
 import styled from 'styled-components'
+import type { LayoutVariant } from '@/components/search/constants'
+import { LayoutVariants } from '@/components/search/constants'
 import { Search as IconSearch, X as IconX } from '@/components/search/icons'
 import { colorGrayscale } from '@twreporter/core/lib/constants/color'
 import { useSearchBox } from 'react-instantsearch'
@@ -9,28 +11,27 @@ const _ = {
   debounce,
 }
 
-export const LayoutVariants = {
-  Default: 'default', // search bar in the body of the page
-  Header: 'header', // search bar in the header
-} as const
-
-export type LayoutVariant = (typeof LayoutVariants)[keyof typeof LayoutVariants]
-
 const Container = styled.div<{ $variant: LayoutVariant }>`
   width: 100%;
   background-color: ${colorGrayscale.white};
 
   ${({ $variant }) => {
-    if ($variant === LayoutVariants.Header) {
-      return `
-        padding: 8px 20px;
+    switch ($variant) {
+      case LayoutVariants.Modal:
+      case LayoutVariants.Header: {
+        return `
+          padding: 8px 20px;
+          height: 40px;
+        `
+      }
+      case LayoutVariants.Default:
+      default: {
+        return `
+        padding: 12px 24px;
         height: 40px;
-      `
+        `
+      }
     }
-    return `
-      padding: 12px 20px;
-      height: 48px;
-    `
   }}
 
   display: flex;

--- a/packages/frontend/src/components/search/search-box.tsx
+++ b/packages/frontend/src/components/search/search-box.tsx
@@ -70,7 +70,7 @@ export const SearchBox = ({
   autoFocus: boolean
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
-  const { query, refine: _refine } = useSearchBox()
+  const { query, refine: _refine, clear } = useSearchBox()
   const [inputValue, setInputValue] = useState(query)
   const refine = useMemo(() => _.debounce(_refine, 500), [_refine])
 
@@ -82,7 +82,7 @@ export const SearchBox = ({
 
   const clearQuery = () => {
     setInputValue('')
-    refine('')
+    clear()
   }
 
   useEffect(() => {

--- a/packages/frontend/src/components/search/search-box.tsx
+++ b/packages/frontend/src/components/search/search-box.tsx
@@ -64,10 +64,12 @@ export const SearchBox = ({
   className,
   variant,
   autoFocus,
+  onFocus,
 }: {
   className?: string
   variant: LayoutVariant
   autoFocus: boolean
+  onFocus?: () => void
 }) => {
   const inputRef = useRef<HTMLInputElement>(null)
   const { query, refine: _refine, clear } = useSearchBox()
@@ -99,6 +101,7 @@ export const SearchBox = ({
         onChange={handleOnChange}
         placeholder="搜尋立委和議題"
         autoFocus={autoFocus}
+        onFocus={onFocus}
       />
       {inputValue && (
         <ClearButton onClick={clearQuery}>

--- a/packages/frontend/src/components/search/search-box.tsx
+++ b/packages/frontend/src/components/search/search-box.tsx
@@ -4,44 +4,15 @@ import styled from 'styled-components'
 import type { LayoutVariant } from '@/components/search/constants'
 import { LayoutVariants } from '@/components/search/constants'
 import { Search as IconSearch, X as IconX } from '@/components/search/icons'
-import { colorGrayscale } from '@twreporter/core/lib/constants/color'
+import {
+  colorGrayscale,
+  colorOpacity,
+} from '@twreporter/core/lib/constants/color'
 import { useSearchBox } from 'react-instantsearch'
 
 const _ = {
   debounce,
 }
-
-const Container = styled.div<{ $variant: LayoutVariant }>`
-  width: 100%;
-  background-color: ${colorGrayscale.white};
-
-  ${({ $variant }) => {
-    switch ($variant) {
-      case LayoutVariants.Modal:
-      case LayoutVariants.Header: {
-        return `
-          padding: 8px 20px;
-          height: 40px;
-        `
-      }
-      case LayoutVariants.Default:
-      default: {
-        return `
-        padding: 12px 24px;
-        height: 40px;
-        `
-      }
-    }
-  }}
-
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 8px;
-
-  border: 1px solid ${colorGrayscale.gray600};
-  border-radius: 40px;
-`
 
 const Input = styled.input`
   width: 100%;
@@ -50,7 +21,46 @@ const Input = styled.input`
   border: 0;
   outline: none;
 
-  color: ${colorGrayscale.gray800};
+  color: ${colorGrayscale.gray500};
+  background-color: transparent;
+`
+
+const Container = styled.div<{ $variant: LayoutVariant; $isFocused: boolean }>`
+  width: 100%;
+  background-color: ${colorOpacity['white_0.8']};
+  border-radius: 40px;
+  border: 1px solid ${colorGrayscale.gray400};
+  &:hover {
+    border: 1px solid ${colorGrayscale.gray600};
+  }
+
+  ${({ $variant, $isFocused }) => {
+    let variantCss = ''
+    switch ($variant) {
+      case LayoutVariants.Modal:
+      case LayoutVariants.Header: {
+        variantCss = 'padding: 0 20px; height: 40px;'
+        break
+      }
+      case LayoutVariants.Default:
+      default: {
+        variantCss = 'padding: 0 24px; height: 48px;'
+      }
+    }
+    const focusCss = $isFocused
+      ? `
+      background-color: ${colorGrayscale.white};
+      ${Input} {
+        color: ${colorGrayscale.gray800};
+      }
+    `
+      : ''
+    return variantCss + focusCss
+  }}
+
+  display: flex;
+  align-items: center;
+  gap: 8px;
 `
 
 const ClearButton = styled.button`
@@ -72,9 +82,11 @@ export const SearchBox = ({
   autoFocus: boolean
   onFocus?: () => void
 }) => {
+  const defaultPlaceholder = '搜尋立委和議題'
   const inputRef = useRef<HTMLInputElement>(null)
   const { query, refine: _refine, clear } = useSearchBox()
   const [inputValue, setInputValue] = useState(query)
+  const [isFocused, setIsFocused] = useState(false)
   const refine = useMemo(() => _.debounce(_refine, 500), [_refine])
 
   const handleOnChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -93,16 +105,22 @@ export const SearchBox = ({
   }, [query])
 
   return (
-    <Container className={className} $variant={variant}>
+    <Container className={className} $variant={variant} $isFocused={isFocused}>
       <IconSearch />
       <Input
         ref={inputRef}
         type="text"
         value={inputValue}
         onChange={handleOnChange}
-        placeholder="搜尋立委和議題"
+        placeholder={isFocused ? '' : defaultPlaceholder}
         autoFocus={autoFocus}
-        onFocus={onFocus}
+        onFocus={() => {
+          setIsFocused(true)
+          onFocus?.()
+        }}
+        onBlur={() => {
+          setIsFocused(false)
+        }}
       />
       {inputValue && (
         <ClearButton onClick={clearQuery}>

--- a/packages/frontend/src/hooks/use-scroll-lock.tsx
+++ b/packages/frontend/src/hooks/use-scroll-lock.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+
+export const useScrollLock = (lock?: boolean) => {
+  useEffect(() => {
+    if (lock) {
+      document.body.style.overflow = 'hidden'
+    } else {
+      document.body.style.overflow = 'unset'
+    }
+    return () => {
+      document.body.style.overflow = 'unset'
+    }
+  }, [lock])
+}


### PR DESCRIPTION
### PR 簡述
此 PR 主要實作 mobile search modal（見 [674bdab](https://github.com/twreporter/congress-dashboard-monorepo/pull/112/commits/674bdab1542f15dafdd9661bd6eb3cc7d1f531f8)），當使用者點擊 search box 時，search bar 會變成蓋板樣式。
請見以下 demo：

![mobile-search-demo](https://github.com/user-attachments/assets/1097a83f-ea5a-4843-821b-8ddd5b9367ad)

另外，也根據設計師的回饋，調整了 `clickOutside` 的效果，原本 `clickOutside` 會清空 query 和搜尋結果，[705709f](https://github.com/twreporter/congress-dashboard-monorepo/pull/112/commits/705709f792a7e41eceae2a39ddd3f72e8b94d8ac) 將其改成「不清空 query，單純隱藏搜尋結果，當使用者點擊 search box 時，再顯示搜尋結果」。