### PR TITLE
refactor(frontend): get algolia app id and search key from env vars

### DIFF
--- a/packages/frontend/.env.dev.public
+++ b/packages/frontend/.env.dev.public
@@ -1,3 +1,5 @@
 NEXT_PUBLIC_RELEASE_BRANCH=dev
 NEXT_PUBLIC_API_URL=https://dev-congress-dashboard.twreporter.org/api/graphql
 NEXT_PUBLIC_IMAGE_HOST=https://dev-congress-dashboard-storage.twreporter.org
+NEXT_PUBLIC_ALGOLIA_APP_ID=V2C76WIIQK
+NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY=7d7fdff9202f5e67c6435f9613be11d9

--- a/packages/frontend/.env.development
+++ b/packages/frontend/.env.development
@@ -1,3 +1,5 @@
 NEXT_PUBLIC_RELEASE_BRANCH=dev
 NEXT_PUBLIC_API_URL=https://dev-congress-dashboard.twreporter.org/api/graphql
 NEXT_PUBLIC_IMAGE_HOST=https://dev-congress-dashboard-storage.twreporter.org
+NEXT_PUBLIC_ALGOLIA_APP_ID=V2C76WIIQK
+NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY=7d7fdff9202f5e67c6435f9613be11d9

--- a/packages/frontend/src/components/search/instant-search.tsx
+++ b/packages/frontend/src/components/search/instant-search.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import useWindowWidth from '@/hooks/use-window-width'
 import styled from 'styled-components'
 import type { LayoutVariant } from '@/components/search/constants'
@@ -13,16 +13,6 @@ import { SearchBox } from '@/components/search/search-box'
 import { SearchModal } from '@/components/search/modal'
 import { ZIndex } from '@/styles/z-index'
 import { liteClient as algoliasearch } from 'algoliasearch/lite'
-
-const algoliaConfig = {
-  appID: process.env.NEXT_PUBLIC_ALGOLIA_APP_ID || '',
-  searchAPIKey: process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY || '',
-}
-
-const searchClient = algoliasearch(
-  algoliaConfig.appID,
-  algoliaConfig.searchAPIKey
-)
 
 export { LayoutVariants }
 
@@ -101,6 +91,25 @@ export const AlgoliaInstantSearch = ({
   const [focused, setFocused] = useState(true)
   const [isModalOpen, setIsModalOpen] = useState(false)
   const windowWidth = useWindowWidth()
+
+  const searchClient = useMemo(() => {
+    if (typeof window === 'undefined') {
+      return null // Don't init on server
+    }
+    const appID = process.env.NEXT_PUBLIC_ALGOLIA_APP_ID
+    const searchKey = process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY
+
+    if (!appID || !searchKey) {
+      console.warn('Missing Algolia credentials')
+      return null
+    }
+
+    return algoliasearch(appID, searchKey)
+  }, [])
+
+  if (!searchClient) {
+    return null // Avoid render if client not ready
+  }
 
   if (isModalOpen) {
     return (

--- a/packages/frontend/src/components/search/instant-search.tsx
+++ b/packages/frontend/src/components/search/instant-search.tsx
@@ -14,10 +14,9 @@ import { SearchModal } from '@/components/search/modal'
 import { ZIndex } from '@/styles/z-index'
 import { liteClient as algoliasearch } from 'algoliasearch/lite'
 
-// TODO: move to constants file and read them from environment variables
 const algoliaConfig = {
-  appID: 'V2C76WIIQK',
-  searchAPIKey: '7d7fdff9202f5e67c6435f9613be11d9',
+  appID: process.env.NEXT_PUBLIC_ALGOLIA_APP_ID || '',
+  searchAPIKey: process.env.NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY || '',
 }
 
 const searchClient = algoliasearch(


### PR DESCRIPTION
### PR 簡述
將 hard code 的 Algolia app ID 和 search API key 改從 NEXT_PUBLIC 的 environment variables 裡拿。

### 需要延伸討論的部分
Algolia 的 app ID 和 search API key 可以揭露在網頁上方，不會有資安問題。
但若有心人士拿到我們的 app ID 和 search API key，他們便可以透過這組 id 和 key 來 query 我們的資料。
等上線後，我們可能會需要監控 request 的量，確認是否有被盜用的情況發生。
