### PR TITLE
fix(frontend): add overflow hidden for title

### DIFF
--- a/packages/frontend/CHANGELOG.md
+++ b/packages/frontend/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 1.0.0-rc.8, 2025-05-09
+
+### Notable Changes
+
+- fix
+  - add overflow hidden for title
+
+### Commits
+
+- [[`11b5c30734`](https://github.com/twreporter/congress-dashboard-monorepo/commit/11b5c30734)] - **fix(frontend)**: add overflow hidden for title (Lucien)
+
 ## 1.0.0-rc.7, 2025-05-09
 
 ### Notable Changes

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@twreporter/congress-dashboard-frontend",
-  "version": "1.0.0-rc.7",
+  "version": "1.0.0-rc.8",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",

--- a/packages/frontend/src/components/speech/styles.ts
+++ b/packages/frontend/src/components/speech/styles.ts
@@ -196,6 +196,7 @@ export const ControlTab = styled.div<{ $isHeaderAbove?: boolean }>`
 export const DateAndTitle = styled.div`
   display: flex;
   flex-direction: row;
+  overflow: hidden;
   gap: 12px;
   ${mq.mobileOnly`
     width: 100%;


### PR DESCRIPTION
# Issue
title too lon...
[[defect] 標題過長時，文字會超出畫面，按鈕看不到](https://www.notion.so/twreporter/defect-1ee8dbdca932802f8e8fcf5db8b52c24?pvs=4)
# Notice
<!-- Related notice or note for this PR -->

# Dependency
<!-- Related dependency of this PR -->
