### PR TITLE
refactor(frontend): use <AlgoliaInstantSearch> in <HamburgerMenu>

### DIFF
--- a/packages/frontend/src/components/hamburger-menu/index.tsx
+++ b/packages/frontend/src/components/hamburger-menu/index.tsx
@@ -8,7 +8,7 @@ import { MenuButton, PillButton } from '@twreporter/react-components/lib/button'
 import Divider from '@twreporter/react-components/lib/divider'
 import { P2 } from '@twreporter/react-components/lib/text/paragraph'
 import { colorGrayscale } from '@twreporter/core/lib/constants/color'
-import { SearchBar } from '@twreporter/react-components/lib/input'
+import { AlgoliaInstantSearch } from '@/components/search/instant-search'
 // z-index
 import { ZIndex } from '@/styles/z-index'
 // constants
@@ -64,9 +64,6 @@ const StyledPillButton = styled(PillButton)`
 `
 
 const SearchSection = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
   padding: 16px 0;
 `
 
@@ -78,19 +75,10 @@ type HamburgerMenuProps = {
   isOpen: boolean
 }
 const HamburgerMenu: React.FC<HamburgerMenuProps> = ({ isOpen }) => {
-  const onSearch = (keywords: string) => {
-    alert(`serch: ${keywords}`)
-  }
-
   return (
     <Container $isOpen={isOpen}>
       <SearchSection>
-        <SearchBar
-          onSearch={onSearch}
-          autofocus={false}
-          widthType="stretch"
-          placeholder="關鍵字搜尋"
-        />
+        <AlgoliaInstantSearch />
       </SearchSection>
       {menuLinks.map(({ text, href, target }, idx) => (
         <MenuButton

--- a/packages/frontend/src/components/header/index.tsx
+++ b/packages/frontend/src/components/header/index.tsx
@@ -28,7 +28,7 @@ import {
 import HamburgerMenu from '@/components/hamburger-menu'
 // hooks
 import useWindowWidth from '@/hooks/use-window-width'
-import { useScrollLock } from '@/hooks/use-scroll-lock'
+import { useBodyScrollLock } from '@/hooks/use-scroll-lock'
 // z-index
 import { ZIndex } from '@/styles/z-index'
 // constants
@@ -156,7 +156,10 @@ const Header: React.FC = () => {
   }, [])
 
   // Handle body scroll lock
-  useScrollLock(isHamburgerOpen)
+  useBodyScrollLock({
+    toLock: isHamburgerOpen,
+    lockID: 'hambuger',
+  })
 
   useEffect(() => {
     if (windowWidth >= DEFAULT_SCREEN.tablet.minWidth) {

--- a/packages/frontend/src/components/search/modal.tsx
+++ b/packages/frontend/src/components/search/modal.tsx
@@ -8,7 +8,7 @@ import { SearchBox } from '@/components/search/search-box'
 import { LayoutVariants } from '@/components/search/constants'
 import { ZIndex } from '@/styles/z-index'
 import { colorGrayscale } from '@twreporter/core/lib/constants/color'
-import { useScrollLock } from '@/hooks/use-scroll-lock'
+import { useBodyScrollLock } from '@/hooks/use-scroll-lock'
 
 const releaseBranch = process.env.NEXT_PUBLIC_RELEASE_BRANCH
 
@@ -38,7 +38,10 @@ export const SearchModal = ({
   onClose: () => void
 }) => {
   // Lock body scroll
-  useScrollLock(true)
+  useBodyScrollLock({
+    toLock: true,
+    lockID: 'search-modal',
+  })
 
   return ReactDOM.createPortal(
     <Overlay className={className}>

--- a/packages/frontend/src/hooks/use-scroll-lock.tsx
+++ b/packages/frontend/src/hooks/use-scroll-lock.tsx
@@ -1,14 +1,23 @@
 import { useEffect } from 'react'
 
-export const useScrollLock = (lock?: boolean) => {
+export const useBodyScrollLock = ({
+  toLock,
+  lockID = '',
+}: {
+  toLock: boolean
+  lockID?: string
+}) => {
   useEffect(() => {
-    if (lock) {
-      document.body.style.overflow = 'hidden'
+    const className = lockID ? `scroll-lock--${lockID}` : `scroll-lock`
+
+    if (toLock) {
+      document.body.classList.add(className)
     } else {
-      document.body.style.overflow = 'unset'
+      document.body.classList.remove(className)
     }
+
     return () => {
-      document.body.style.overflow = 'unset'
+      document.body.classList.remove(className)
     }
-  }, [lock])
+  }, [toLock, lockID])
 }

--- a/packages/frontend/src/styles/global-styles.ts
+++ b/packages/frontend/src/styles/global-styles.ts
@@ -11,6 +11,10 @@ const GlobalStyles = createGlobalStyle`
     margin-top: 64px; // header height
   }
 
+  body.scroll-lock, body[class*='scroll-lock--'] {
+    overflow: hidden;
+  }
+
   @media print {
     .hidden-print {
       display: none !important;


### PR DESCRIPTION
### PR 簡述
調整 hambuger menu 裡的 search bar，改用 `AlgoliaInstantSearch`。

### 實作細節
因為 `HambugerMenu` 和 `AlogliaInstantSearch` 都會使用 `useScrollLock`，而 `useScrollLock` 是直接調整 `body.style.overflow`，會遇到兩個 `useScrollLock` 互相打架，而導致 body scroll lock 失效的問題。
例如：
當我先打開 hambuger menu 後，再點擊 search bar，會有另一個 search modal 覆蓋 hambuger menu。
menu 和 search bar 都會將 `body.style.overflow` 設定成 `hidden`，藉此鎖住 body。
但我們關閉 search bar 時，`useScrollLock` cleanup function 會將 `body.style.overflow` 設定成 `unset`，此時，雖然 menu 仍然開啟，但 body 卻已經可以 scroll。

commit [77afcc5](https://github.com/twreporter/congress-dashboard-monorepo/pull/123/commits/77afcc5a2d999ae5cb4c283ab54bbeb76f7f0a93) 調整 lock 的機制，讓 `useScrollLock` 不會互相影響，解決「關閉 search bar 後 menu 的 scroll lock 失效的問題」。 
