### PR TITLE
refactor(frontend): refactor type convention. Add @/types/index.ts

### DIFF
--- a/packages/frontend/src/components/search/constants.ts
+++ b/packages/frontend/src/components/search/constants.ts
@@ -1,7 +1,9 @@
+import type { ValuesOf } from '@/types/index'
+
 export const LayoutVariants = {
   Default: 'default', // search bar in the body of the page
   Header: 'header', // search bar in the header
   Modal: 'modal', // search bar in the modal
 } as const
 
-export type LayoutVariant = (typeof LayoutVariants)[keyof typeof LayoutVariants]
+export type LayoutVariant = ValuesOf<typeof LayoutVariants>

--- a/packages/frontend/src/types/index.ts
+++ b/packages/frontend/src/types/index.ts
@@ -1,0 +1,3 @@
+export * from '@/types/navigation-link'
+
+export type ValuesOf<T> = T[keyof T]


### PR DESCRIPTION
### PR 簡述
根據今日會議結論，將 `type LayoutVariant = (typeof LayoutVariants)[keyof typeof LayoutVariants]` 改寫成 `type LayoutVariant = ValuesOf<typeof LayoutVariants>`