### PR TITLE
refactor(cms): two-sided relationship between Speech and LegislativeYuanMember

### DIFF
--- a/packages/cms/lists/LegislativeYuanMember.ts
+++ b/packages/cms/lists/LegislativeYuanMember.ts
@@ -88,6 +88,19 @@ const listConfigurations = list({
         labelField: 'term',
       },
     }),
+    speeches: relationship({
+      ref: 'Speech.legislativeYuanMember',
+      label: '發言紀錄',
+      many: true,
+      ui: {
+        createView: {
+          fieldMode: 'hidden',
+        },
+        itemView: {
+          fieldMode: 'read',
+        },
+      },
+    }),
     sessionAndCommittee: relationship({
       ref: 'CommitteeMember.legislativeYuanMember',
       many: true,

--- a/packages/cms/lists/Speech.ts
+++ b/packages/cms/lists/Speech.ts
@@ -25,8 +25,9 @@ const listConfigurations = list({
       },
     }),
     legislativeYuanMember: relationship({
-      ref: 'LegislativeYuanMember',
+      ref: 'LegislativeYuanMember.speeches',
       label: '立委屆資',
+      many: false,
       ui: {
         labelField: 'labelForCMS',
       },

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -632,6 +632,8 @@ type LegislativeYuanMember {
   labelForCMS: String
   party: Party
   legislativeMeeting: LegislativeMeeting
+  speeches(where: SpeechWhereInput! = {}, orderBy: [SpeechOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: SpeechWhereUniqueInput): [Speech!]
+  speechesCount(where: SpeechWhereInput! = {}): Int
   sessionAndCommittee(where: CommitteeMemberWhereInput! = {}, orderBy: [CommitteeMemberOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CommitteeMemberWhereUniqueInput): [CommitteeMember!]
   sessionAndCommitteeCount(where: CommitteeMemberWhereInput! = {}): Int
   type: String
@@ -657,6 +659,7 @@ input LegislativeYuanMemberWhereInput {
   labelForCMS: StringFilter
   party: PartyWhereInput
   legislativeMeeting: LegislativeMeetingWhereInput
+  speeches: SpeechManyRelationFilter
   sessionAndCommittee: CommitteeMemberManyRelationFilter
   type: StringFilter
   constituency: StringNullableFilter
@@ -706,6 +709,7 @@ input LegislativeYuanMemberUpdateInput {
   labelForCMS: String
   party: PartyRelateToOneForUpdateInput
   legislativeMeeting: LegislativeMeetingRelateToOneForUpdateInput
+  speeches: SpeechRelateToManyForUpdateInput
   sessionAndCommittee: CommitteeMemberRelateToManyForUpdateInput
   type: String
   constituency: String
@@ -740,6 +744,7 @@ input LegislativeYuanMemberCreateInput {
   labelForCMS: String
   party: PartyRelateToOneForCreateInput
   legislativeMeeting: LegislativeMeetingRelateToOneForCreateInput
+  speeches: SpeechRelateToManyForCreateInput
   sessionAndCommittee: CommitteeMemberRelateToManyForCreateInput
   type: String
   constituency: String

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -114,24 +114,24 @@ model Legislator {
 }
 
 model LegislativeYuanMember {
-  id                                Int                 @id @default(autoincrement())
-  legislator                        Legislator?         @relation("LegislativeYuanMember_legislator", fields: [legislatorId], references: [id])
-  legislatorId                      Int?                @map("legislator")
-  labelForCMS                       String              @default("")
-  party                             Party?              @relation("LegislativeYuanMember_party", fields: [partyId], references: [id])
-  partyId                           Int?                @map("party")
-  legislativeMeeting                LegislativeMeeting? @relation("LegislativeYuanMember_legislativeMeeting", fields: [legislativeMeetingId], references: [id])
-  legislativeMeetingId              Int?                @map("legislativeMeeting")
-  sessionAndCommittee               CommitteeMember[]   @relation("CommitteeMember_legislativeYuanMember")
-  type                              String
-  constituency                      String?
-  city                              String?
-  tooltip                           String              @default("")
-  note                              String              @default("")
-  proposalSuccessCount              Int?
-  createdAt                         DateTime?           @default(now())
-  updatedAt                         DateTime?           @updatedAt
-  from_Speech_legislativeYuanMember Speech[]            @relation("Speech_legislativeYuanMember")
+  id                   Int                 @id @default(autoincrement())
+  legislator           Legislator?         @relation("LegislativeYuanMember_legislator", fields: [legislatorId], references: [id])
+  legislatorId         Int?                @map("legislator")
+  labelForCMS          String              @default("")
+  party                Party?              @relation("LegislativeYuanMember_party", fields: [partyId], references: [id])
+  partyId              Int?                @map("party")
+  legislativeMeeting   LegislativeMeeting? @relation("LegislativeYuanMember_legislativeMeeting", fields: [legislativeMeetingId], references: [id])
+  legislativeMeetingId Int?                @map("legislativeMeeting")
+  speeches             Speech[]            @relation("Speech_legislativeYuanMember")
+  sessionAndCommittee  CommitteeMember[]   @relation("CommitteeMember_legislativeYuanMember")
+  type                 String
+  constituency         String?
+  city                 String?
+  tooltip              String              @default("")
+  note                 String              @default("")
+  proposalSuccessCount Int?
+  createdAt            DateTime?           @default(now())
+  updatedAt            DateTime?           @updatedAt
 
   @@index([legislatorId])
   @@index([partyId])


### PR DESCRIPTION
### PR 簡述
根據 search data feed 的需求：**每位立委的最新一筆發言時間**，GQL 需要提供「從 LegislativeYuanMember 中，查詢該 member 擁有哪些 speeches」的功能。

因為 LegislativeYuanMember 本身就已經和 Speech 有 one-to-many 的 relationship，只是目前是 one-sided 的寫法，所以 LegislativeYuanMember 不能下 `where.speech` filter 條件。

此 PR 將其改寫為 two-sided one-to-many relationship。
