### PR TITLE
fix(cms): update related article import logic

### DIFF
--- a/.changeset/clear-baboons-taste.md
+++ b/.changeset/clear-baboons-taste.md
@@ -1,0 +1,5 @@
+---
+'@twreporter/congress-dashboard-cms': patch
+---
+
+fix import twreporter related articles logic


### PR DESCRIPTION
# Issue
fix defects in [[報導者觀測站] CMS資料匯入-相關文章](https://www.notion.so/twreporter/CMS-1fc8dbdca93280f4aedef284d9a23d93?source=copy_link)

# Notice
The duplicated article slugs would still update its order in this version

# Dependency
N/A
