### PR TITLE
fix(cms): `/import-records` list page hangs, and can not show any data

### DIFF
--- a/packages/cms/lists/ImportRecord.ts
+++ b/packages/cms/lists/ImportRecord.ts
@@ -912,7 +912,7 @@ const listConfigurations = list({
     listView: {
       initialColumns: [
         'recordName',
-        'uploadData',
+        // 'uploadData',
         'recordCount',
         'createdAt',
         'updatedAt',


### PR DESCRIPTION
## Issue
資料匯入（`/import-records`）頁面 hang 住，無法正常呈現列表頁。
目前推測是 `uploadData` 資料量太大，導致 graphql 無法正常回傳資料，先將 `uploadData` 欄位註解掉，看看問題是否改善。
