### PR TITLE
fix(cms): `/import-records` list page hangs, and can not show any data

### DIFF
--- a/.changeset/lazy-houses-shake.md
+++ b/.changeset/lazy-houses-shake.md
@@ -1,0 +1,5 @@
+---
+'@twreporter/congress-dashboard-cms': patch
+---
+
+fix(cms): /import-records list page hangs, and can not show any data

--- a/packages/cms/lists/ImportRecord.ts
+++ b/packages/cms/lists/ImportRecord.ts
@@ -912,7 +912,7 @@ const listConfigurations = list({
     listView: {
       initialColumns: [
         'recordName',
-        'uploadData',
+        // 'uploadData',
         'recordCount',
         'createdAt',
         'updatedAt',


### PR DESCRIPTION
### Issue
記者和 PM 回報網頁打開 `/import-records` 列表頁時，頁面會 hang 在 loading 畫面，無法順利載入列表。

### Root Cause
Keystone web UI 再打開列表頁時，會先發 GraphQL request 去拿 10 筆資料。
因為 `ImportRecord.listView.initialColumns` 包含 `uploadData`，所以 GQL request 的 query 會包含 `uploadData` field。
但是 `uploadData` 的資料量不小，如果一次要拿 10 筆包含 `uploadData` 的資料，GQL server 會回傳 500 response status，導致列表頁無法順利呈現畫面。

### Solution
因為列表頁並不需要呈現 `uploadData` 等細節，所以先把 `uploadData` 註解掉，讓 GQL 不會因為 response 資料量太大而發生錯誤。

### 後續
在 debug 時，發現可以優化的事情，包含：
1. GQL server 在回傳 500 status response 時，並沒有提供任何可以 debug 的資訊，包含 request body 或是 server error 錯誤的細節。
2. GQL server 發生 server side error 時，沒有串接 error reporting，所以工程師無法第一時間掌握錯誤狀況。