### PR TITLE
fix(frontend): next/image cannot show image from `lawmaker.twreporter.org`

### DIFF
--- a/.changeset/ripe-plants-rescue.md
+++ b/.changeset/ripe-plants-rescue.md
@@ -1,0 +1,5 @@
+---
+'@twreporter/congress-dashboard-frontend': patch
+---
+
+add prod host to next image domain white list

--- a/packages/frontend/next.config.ts
+++ b/packages/frontend/next.config.ts
@@ -8,6 +8,7 @@ const nextConfig: NextConfig = {
     domains: [
       'dev-lawmaker.twreporter.org',
       'staging-lawmaker.twreporter.org',
+      'lawmaker.twreporter.org',
       'dev.twreporter.org',
       'staging.twreporter.org',
       'twreporter.org',


### PR DESCRIPTION
# Issue
[[hotfix-觀測站] 有幾處立委照片無法正常顯示](https://www.notion.so/twreporter/hotfix-2418dbdca93280bcb40cd7f8b028bcc0?source=copy_link)

# Dependency
N/A