### PR TITLE
feat: use ISR on production & SSR on other envs

### DIFF
--- a/packages/frontend/src/app/a/[slug]/page.tsx
+++ b/packages/frontend/src/app/a/[slug]/page.tsx
@@ -1,3 +1,9 @@
+const isRelease = process.env.NEXT_PUBLIC_RELEASE_BRANCH === 'release'
+// use ISR in production & SSR in other envs (disabled cache)
+export const dynamic = isRelease ? 'auto' : 'force-dynamic'
+// cache html & data for 2hr in release
+export const revalidate = isRelease ? 7200 : undefined
+
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 // components
@@ -7,8 +13,6 @@ import { fetchSpeech, fetchSpeechGroup } from '@/fetchers/server/speech'
 // constants
 import { InternalRoutes } from '@/constants/routes'
 import { OG_IMAGE_URL } from '@/constants'
-
-export const dynamicParams = true
 
 export async function generateMetadata({
   params,

--- a/packages/frontend/src/app/about/page.tsx
+++ b/packages/frontend/src/app/about/page.tsx
@@ -1,4 +1,8 @@
-export const dynamic = 'force-dynamic'
+const isRelease = process.env.NEXT_PUBLIC_RELEASE_BRANCH === 'release'
+// use ISR in production & SSR in other envs (disabled cache)
+export const dynamic = isRelease ? 'auto' : 'force-dynamic'
+// cache html & data for 2hr in release
+export const revalidate = isRelease ? 7200 : undefined
 
 import { cache } from 'react'
 import { Metadata } from 'next'

--- a/packages/frontend/src/app/lawmaker/[slug]/page.tsx
+++ b/packages/frontend/src/app/lawmaker/[slug]/page.tsx
@@ -1,3 +1,9 @@
+const isRelease = process.env.NEXT_PUBLIC_RELEASE_BRANCH === 'release'
+// use ISR in production & SSR in other envs (disabled cache)
+export const dynamic = isRelease ? 'auto' : 'force-dynamic'
+// cache html & data for 2hr in release
+export const revalidate = isRelease ? 7200 : undefined
+
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 // fetchers
@@ -14,8 +20,6 @@ import { validateMeetingParams } from '@/utils/validate-meeting-params'
 // constants
 import { InternalRoutes } from '@/constants/routes'
 import { OG_IMAGE_URL } from '@/constants'
-
-export const dynamicParams = true
 
 export async function generateMetadata({
   params,

--- a/packages/frontend/src/app/page.tsx
+++ b/packages/frontend/src/app/page.tsx
@@ -1,4 +1,8 @@
-export const dynamic = 'force-dynamic'
+const isRelease = process.env.NEXT_PUBLIC_RELEASE_BRANCH === 'release'
+// use ISR in production & SSR in other envs (disabled cache)
+export const dynamic = isRelease ? 'auto' : 'force-dynamic'
+// cache html & data for 2hr in release
+export const revalidate = isRelease ? 7200 : undefined
 
 // fetcher
 import fetchEditorSelecteds from '@/fetchers/server/editor-pickor'

--- a/packages/frontend/src/app/topics/[slug]/page.tsx
+++ b/packages/frontend/src/app/topics/[slug]/page.tsx
@@ -1,3 +1,9 @@
+const isRelease = process.env.NEXT_PUBLIC_RELEASE_BRANCH === 'release'
+// use ISR in production & SSR in other envs (disabled cache)
+export const dynamic = isRelease ? 'auto' : 'force-dynamic'
+// cache html & data for 2hr in release
+export const revalidate = isRelease ? 7200 : undefined
+
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 // components
@@ -10,8 +16,6 @@ import { validateMeetingParams } from '@/utils/validate-meeting-params'
 import { InternalRoutes } from '@/constants/routes'
 // constants
 import { OG_IMAGE_URL } from '@/constants'
-
-export const dynamicParams = true
 
 export async function generateMetadata({
   params,


### PR DESCRIPTION
# Issue
[[觀測站] prod 增加 cache 設定](https://www.notion.so/twreporter/prod-cache-2408dbdca93280f6a19ee4cd7818c300?source=copy_link)

# Notice
- `force-dynamic` (SSR) would disabled data cache as well (set `cache-controll`: none to `fetcher`)
- set `revalidate` (ISR) on page.tsx would also set cache-controll with same value for `fetcher`
- next.js cache [ref](https://nextjs.org/docs/app/guides/caching)
  - error would not be cached by ISR ([ref](https://nextjs.org/docs/app/guides/incremental-static-regeneration#handling-uncaught-exceptions))

# Dependency
N/A
