### PR TITLE
fix(frontend): prerender failed on next build

### DIFF
--- a/packages/frontend/src/app/a/[slug]/page.tsx
+++ b/packages/frontend/src/app/a/[slug]/page.tsx
@@ -1,6 +1,6 @@
 // use ISR cache 2hr
-export const dynamic = 'auto'
 export const revalidate = 7200
+export const dynamicParams = true
 
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'

--- a/packages/frontend/src/app/about/page.tsx
+++ b/packages/frontend/src/app/about/page.tsx
@@ -1,6 +1,5 @@
-// use ISR cache 2hr
-export const dynamic = 'auto'
-export const revalidate = 7200
+// about page cache is on cloudflare
+export const dynamic = 'force-dynamic'
 
 import { cache } from 'react'
 import { Metadata } from 'next'

--- a/packages/frontend/src/app/lawmaker/[slug]/page.tsx
+++ b/packages/frontend/src/app/lawmaker/[slug]/page.tsx
@@ -1,6 +1,6 @@
 // use ISR cache 2hr
-export const dynamic = 'auto'
 export const revalidate = 7200
+export const dynamicParams = true
 
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'

--- a/packages/frontend/src/app/page.tsx
+++ b/packages/frontend/src/app/page.tsx
@@ -1,6 +1,5 @@
-// use ISR cache 2hr
-export const dynamic = 'auto'
-export const revalidate = 7200
+// home page cache is on cloudflare
+export const dynamic = 'force-dynamic'
 
 // fetcher
 import fetchEditorSelecteds from '@/fetchers/server/editor-pickor'

--- a/packages/frontend/src/app/topics/[slug]/page.tsx
+++ b/packages/frontend/src/app/topics/[slug]/page.tsx
@@ -1,6 +1,6 @@
 // use ISR cache 2hr
 export const dynamic = 'auto'
-export const revalidate = 7200
+export const dynamicParams = true
 
 import { Metadata } from 'next'
 import { notFound } from 'next/navigation'


### PR DESCRIPTION
# Issue
[[觀測站] prod 增加 cache 設定](https://www.notion.so/twreporter/prod-cache-2408dbdca93280f6a19ee4cd7818c300?source=copy_link)

# Notice
prerender fail on next build because fetch require auth, set dynamicParams as true to prevent prerender on `[slug]` pages & set html cache on cloudflare instead on other page

# Dependency
N/A