### PR TITLE
refactor(frontend): align Algolia record schema with new naming convention

### DIFF
--- a/packages/frontend/src/components/search/instant-hit.tsx
+++ b/packages/frontend/src/components/search/instant-hit.tsx
@@ -18,7 +18,7 @@ export type LegislatorRawHit = Hit<{
   desc: string
   shortDesc: string
   imgSrc: string
-  term: number
+  meetingTerm: number
   lastSpeechAt?: string
   partyImgSrc: string
 }>
@@ -28,8 +28,7 @@ export type TopicRawHit = Hit<{
   name: string
   slug: string
   desc: string
-  term: number
-  session: number
+  meetingTerm: number
   lastSpeechAt?: string
   relatedMessageCount: number
 }>
@@ -152,7 +151,7 @@ export function InstantLegislatorHit({
 }) {
   return (
     <a // use <a> to force full reload
-      href={`${InternalRoutes.Legislator}/${hit.slug}?meetingTerm=${hit.term}`}
+      href={`${InternalRoutes.Legislator}/${hit.slug}?meetingTerm=${hit.meetingTerm}`}
     >
       <InstantHitContainer $variant={variant}>
         <Avatar $imgSrc={hit.imgSrc}>
@@ -176,7 +175,7 @@ export function InstantTopicHit({
 }) {
   return (
     <a // use <a> to force full reload
-      href={`${InternalRoutes.Topic}/${hit.slug}?meetingTerm=${hit.term}&sessionTerm=[${hit.session}]`}
+      href={`${InternalRoutes.Topic}/${hit.slug}?meetingTerm=${hit.meetingTerm}`}
     >
       <InstantHitContainer $variant={variant}>
         <TopicCircle>

--- a/packages/frontend/src/components/search/result-page/hit.tsx
+++ b/packages/frontend/src/components/search/result-page/hit.tsx
@@ -25,8 +25,8 @@ export type SpeechRawHit = Hit<{
   slug: string
   title: string
   summary: string
-  term: number
-  session: number
+  meetingTerm: number
+  sessionTerm: number
   date: string
   legislatorName: string
 }>
@@ -174,7 +174,7 @@ const Container = styled.div`
 export function LegislatorHit({ hit }: { hit: LegislatorRawHit }) {
   return (
     <Link
-      href={`${InternalRoutes.Legislator}/${hit.slug}?meetingTerm=${hit.term}`}
+      href={`${InternalRoutes.Legislator}/${hit.slug}?meetingTerm=${hit.meetingTerm}`}
     >
       <Container>
         <Text>
@@ -228,7 +228,7 @@ export function TopicHit({ hit }: { hit: TopicRawHit }) {
   }
   return (
     <Link
-      href={`${InternalRoutes.Topic}/${hit.slug}?meetingTerm=${hit.term}&sessionTerm=[${hit.session}]`}
+      href={`${InternalRoutes.Topic}/${hit.slug}?meetingTerm=${hit.meetingTerm}`}
     >
       <Container>
         <Text>
@@ -285,7 +285,7 @@ export function SpeechHit({ hit }: { hit: SpeechRawHit }) {
 
   return (
     <Link
-      href={`${InternalRoutes.Speech}/${hit.slug}?meetingTerm=${hit.term}&sessionTerm=[${hit.session}]`}
+      href={`${InternalRoutes.Speech}/${hit.slug}?meetingTerm=${hit.meetingTerm}&sessionTerm=[${hit.sessionTerm}]`}
     >
       <Container>
         <Text>

--- a/packages/frontend/src/components/search/result-page/index.tsx
+++ b/packages/frontend/src/components/search/result-page/index.tsx
@@ -141,11 +141,11 @@ const SearchResults = ({ className, query }: SearchResultsProps) => {
   const meetingSession = filterValue.meetingSession
 
   if (meeting !== 'all') {
-    const meetingFilter = `term: ${meeting}`
+    const meetingFilter = `meetingTerm: ${meeting}`
     const meetingSessionFilter =
       meetingSession.indexOf('all') > -1
         ? ''
-        : meetingSession.map((s) => `session: ${s}`).join(' OR ')
+        : meetingSession.map((s) => `sessionTerm: ${s}`).join(' OR ')
     filters = meetingSessionFilter
       ? `(${meetingFilter}) AND (${meetingSessionFilter})`
       : meetingFilter


### PR DESCRIPTION
### Issue
[[觀測站優化]搜尋結果需為最新「屆期」](https://www.notion.so/twreporter/2658dbdca9328035bd52d2aa2c92c5a7)

### 實作細節
Algolia 上的資料的結構會有調整，主要是包含下面兩項：
1. topic 的資料結構調整：移除 `session`（會期） property（只保留屆期）
2. topic, speech and legislator 的資料結構調整： `term` -> `meetingTerm`, `session` -> `sessionTerm`