### PR TITLE
feat(frontend): remove current year for copyright text

### DIFF
--- a/packages/frontend/src/components/footer/index.tsx
+++ b/packages/frontend/src/components/footer/index.tsx
@@ -257,18 +257,14 @@ const Footer: React.FC = () => {
               <P3Gray600 text="｜" />
               <BottomLinks releaseBranch={releaseBranch} />
               <P3Gray600 text="｜" />
-              <P3Gray600
-                text={`Copyright © ${new Date().getFullYear()} The Reporter.`}
-              />
+              <P3Gray600 text={'Copyright © The Reporter.'} />
             </DesktopAndAboveWithFlex>
             <TabletAndBelowWithFlex>
               <SocialMediaIcons />
               <Gap $height={24} />
               <P3Gray600 text={fundraisingId} />
               <BottomLinks releaseBranch={releaseBranch} />
-              <P3Gray600
-                text={`Copyright © ${new Date().getFullYear()} The Reporter.`}
-              />
+              <P3Gray600 text={'Copyright © The Reporter.'} />
             </TabletAndBelowWithFlex>
           </BottomSection>
           <BottomSection>

--- a/packages/frontend/src/components/footer/index.tsx
+++ b/packages/frontend/src/components/footer/index.tsx
@@ -257,14 +257,14 @@ const Footer: React.FC = () => {
               <P3Gray600 text="｜" />
               <BottomLinks releaseBranch={releaseBranch} />
               <P3Gray600 text="｜" />
-              <P3Gray600 text={'Copyright © The Reporter.'} />
+              <P3Gray600 text="Copyright © The Reporter." />
             </DesktopAndAboveWithFlex>
             <TabletAndBelowWithFlex>
               <SocialMediaIcons />
               <Gap $height={24} />
               <P3Gray600 text={fundraisingId} />
               <BottomLinks releaseBranch={releaseBranch} />
-              <P3Gray600 text={'Copyright © The Reporter.'} />
+              <P3Gray600 text="Copyright © The Reporter." />
             </TabletAndBelowWithFlex>
           </BottomSection>
           <BottomSection>


### PR DESCRIPTION
# Issue
[[維運]版權標示的更正-footer 顯示修改](https://www.notion.so/twreporter/footer-3138dbdca9328048803bdfb01b77c18f?source=copy_link)

# Notice
<!-- Related notice or note for this PR -->

# Dependency
<!-- Related dependency of this PR -->
