### PR TITLE
chore: update Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,7 @@
 node_modules
+**/node_modules
+.git
+.DS_Store
+**/.DS_Store
+packages/cms/.keystone
+*.private

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,6 +20,8 @@ steps:
 
   # Build image
   - name: gcr.io/cloud-builders/docker
+    env:
+      - DOCKER_BUILDKIT=1
     args:
       - '-c'
       - |

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,9 +9,7 @@ steps:
   #  args:
   #    - '-c'
   #    - |
-  #      cp yarn.lock packages/$_TARGET_PACKAGE
-  #      cd packages/$_TARGET_PACKAGE
-  #      /kaniko/executor --context="$(pwd)" --cache=true --cache-ttl=48h --destination=gcr.io/$PROJECT_ID/$_IMAGE_NAME:${_BRANCH_NAME}_${SHORT_SHA}
+  #      /kaniko/executor --context="$(pwd)" --dockerfile=packages/$_TARGET_PACKAGE/Dockerfile --cache=true --cache-ttl=48h --destination=gcr.io/$PROJECT_ID/$_IMAGE_NAME:${_BRANCH_NAME}_${SHORT_SHA}
 
   # Pull previous image
   - name: gcr.io/cloud-builders/docker
@@ -24,22 +22,16 @@ steps:
   - name: gcr.io/cloud-builders/docker
     args:
       - '-c'
-      - >
-        cp yarn.lock packages/$_TARGET_PACKAGE
-
-        cd packages/$_TARGET_PACKAGE
-
-        echo 'copy .env.${_BRANCH_NAME}.public to .env.local'
-
-        cp .env.${_BRANCH_NAME}.public .env.local
-
+      - |
+        if [[ -f "packages/$_TARGET_PACKAGE/.env.${_BRANCH_NAME}.public" ]]; then
+          echo 'copy .env.${_BRANCH_NAME}.public to .env.local'
+          cp "packages/$_TARGET_PACKAGE/.env.${_BRANCH_NAME}.public" "packages/$_TARGET_PACKAGE/.env.local"
+        fi
         docker build -t \
-
-        gcr.io/$PROJECT_ID/$_IMAGE_NAME:${_BRANCH_NAME}_${SHORT_SHA} \
-
-        -t gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest \
-
-        --cache-from gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest .
+          gcr.io/$PROJECT_ID/$_IMAGE_NAME:${_BRANCH_NAME}_${SHORT_SHA} \
+          -t gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest \
+          --cache-from gcr.io/$PROJECT_ID/$_IMAGE_NAME:latest \
+          -f packages/$_TARGET_PACKAGE/Dockerfile .
     entrypoint: bash
 
   # Push container image to registry

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
       "prettier --write"
     ]
   },
-  "packageManager": "yarn@4.6.0"
+  "packageManager": "yarn@4.6.0",
+  "engines": {
+    "node": "22.23.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "prepare": "husky",
     "build:shared": "yarn workspace @twreporter/congress-dashboard-shared build",
-    "postinstall": "yarn build:shared",
+    "postinstall": "node -e \"if (process.env.SKIP_BUILD_DEPS !== 'true') require('child_process').execFileSync('yarn', ['build:shared'], {stdio:'inherit'})\"",
     "publish:shared": "yarn workspace @twreporter/congress-dashboard-shared publish",
     "version:bump": "lerna version --conventional-commits --yes",
     "postversion": "yarn install --immutable"

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -1,34 +1,59 @@
-ARG NODE_VERSION=22.17.1
+ARG NODE_VERSION=22.23.1
 
 FROM node:${NODE_VERSION}-slim AS builder
 
-ENV APP_DIR /app
+ENV APP_DIR=/app
 
 WORKDIR $APP_DIR
 
-COPY package.json yarn.lock tsconfig.json $APP_DIR/
-COPY src $APP_DIR/src
+RUN corepack enable
 
-RUN yarn install
+COPY package.json yarn.lock .yarnrc.yml $APP_DIR/
+COPY packages/cms/package.json packages/cms/package.json
+COPY packages/cli/package.json packages/cli/package.json
+COPY packages/frontend/package.json packages/frontend/package.json
+COPY packages/shared/package.json packages/shared/package.json
 
-RUN yarn build
+COPY packages/shared packages/shared
+COPY packages/cli packages/cli
 
-FROM node:${NODE_VERSION}-slim
+RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus lawmaker-cli @twreporter/congress-dashboard-shared
+RUN yarn workspace @twreporter/congress-dashboard-shared build
+RUN yarn workspace lawmaker-cli build
 
-ENV APP_DIR /app
+FROM node:${NODE_VERSION}-slim AS production-deps
+
+ENV APP_DIR=/app
 
 WORKDIR $APP_DIR
 
-# NOTE: This image build assumes that yarn.lock is present in the build context.
-# In our CI, cloudbuild.yaml copies the repo-root yarn.lock into this package
-# so that it ends up at /app/yarn.lock in the builder stage. If yarn.lock is
-# not provided in the build context, the COPY below will fail and the image
-# build will not succeed. Ensure your build setup provides yarn.lock at the
-# root of the context before invoking this Dockerfile.
-COPY --from=builder /app/package.json /app/yarn.lock ./
-COPY --from=builder /app/lib ./lib
+RUN corepack enable
 
-RUN yarn install --production=true
+COPY package.json yarn.lock .yarnrc.yml $APP_DIR/
+COPY packages/cms/package.json packages/cms/package.json
+COPY packages/cli/package.json packages/cli/package.json
+COPY packages/frontend/package.json packages/frontend/package.json
+COPY packages/shared/package.json packages/shared/package.json
+
+COPY packages/shared packages/shared
+COPY packages/cli packages/cli
+
+RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus lawmaker-cli --production && yarn cache clean
+COPY --from=builder $APP_DIR/packages/shared/lib packages/shared/lib
+
+FROM node:${NODE_VERSION}-slim AS runner
+
+ENV APP_DIR=/app
+
+WORKDIR $APP_DIR
+
+COPY --from=production-deps $APP_DIR/node_modules ./node_modules
+COPY --from=production-deps $APP_DIR/packages/shared/package.json ./packages/shared/package.json
+COPY --from=production-deps $APP_DIR/packages/shared/lib ./packages/shared/lib
+COPY --from=builder $APP_DIR/packages/cli/package.json packages/cli/package.json
+COPY --from=builder $APP_DIR/packages/cli/lib packages/cli/lib
+
+WORKDIR $APP_DIR/packages/cli
 
 ENV NODE_ENV=production
 

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG NODE_VERSION=22.23.1
 
 FROM node:${NODE_VERSION}-slim AS builder
@@ -9,10 +11,7 @@ WORKDIR $APP_DIR
 RUN corepack enable
 
 COPY package.json yarn.lock .yarnrc.yml $APP_DIR/
-COPY packages/cms/package.json packages/cms/package.json
-COPY packages/cli/package.json packages/cli/package.json
-COPY packages/frontend/package.json packages/frontend/package.json
-COPY packages/shared/package.json packages/shared/package.json
+COPY --parents ./packages/*/package.json ./
 
 RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus lawmaker-cli @twreporter/congress-dashboard-shared
 
@@ -31,10 +30,7 @@ WORKDIR $APP_DIR
 RUN corepack enable
 
 COPY package.json yarn.lock .yarnrc.yml $APP_DIR/
-COPY packages/cms/package.json packages/cms/package.json
-COPY packages/cli/package.json packages/cli/package.json
-COPY packages/frontend/package.json packages/frontend/package.json
-COPY packages/shared/package.json packages/shared/package.json
+COPY --parents ./packages/*/package.json ./
 
 RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus lawmaker-cli --production && yarn cache clean
 COPY --from=builder $APP_DIR/packages/shared/lib packages/shared/lib
@@ -45,10 +41,7 @@ ENV APP_DIR=/app
 
 WORKDIR $APP_DIR
 
-COPY --from=production-deps $APP_DIR/node_modules ./node_modules
-COPY --from=production-deps $APP_DIR/packages/shared/package.json ./packages/shared/package.json
-COPY --from=production-deps $APP_DIR/packages/shared/lib ./packages/shared/lib
-COPY --from=builder $APP_DIR/packages/cli/package.json packages/cli/package.json
+COPY --from=production-deps $APP_DIR $APP_DIR
 COPY --from=builder $APP_DIR/packages/cli/lib packages/cli/lib
 
 WORKDIR $APP_DIR/packages/cli

--- a/packages/cli/Dockerfile
+++ b/packages/cli/Dockerfile
@@ -14,10 +14,11 @@ COPY packages/cli/package.json packages/cli/package.json
 COPY packages/frontend/package.json packages/frontend/package.json
 COPY packages/shared/package.json packages/shared/package.json
 
+RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus lawmaker-cli @twreporter/congress-dashboard-shared
+
 COPY packages/shared packages/shared
 COPY packages/cli packages/cli
 
-RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus lawmaker-cli @twreporter/congress-dashboard-shared
 RUN yarn workspace @twreporter/congress-dashboard-shared build
 RUN yarn workspace lawmaker-cli build
 
@@ -34,9 +35,6 @@ COPY packages/cms/package.json packages/cms/package.json
 COPY packages/cli/package.json packages/cli/package.json
 COPY packages/frontend/package.json packages/frontend/package.json
 COPY packages/shared/package.json packages/shared/package.json
-
-COPY packages/shared packages/shared
-COPY packages/cli packages/cli
 
 RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus lawmaker-cli --production && yarn cache clean
 COPY --from=builder $APP_DIR/packages/shared/lib packages/shared/lib

--- a/packages/cms/Dockerfile
+++ b/packages/cms/Dockerfile
@@ -44,6 +44,8 @@ RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces foc
 COPY packages/cms packages/cms
 COPY --from=build $APP_DIR/packages/shared/lib packages/shared/lib
 
+RUN yarn workspace @twreporter/congress-dashboard-cms postinstall
+
 FROM node:22.23.1-slim AS runner
 
 ## Install system dependencies, `gcsfuse` in particular.

--- a/packages/cms/Dockerfile
+++ b/packages/cms/Dockerfile
@@ -1,4 +1,50 @@
-FROM node:22.23.1
+FROM node:22.23.1-slim AS build
+
+ENV APP_DIR=/app
+
+WORKDIR $APP_DIR
+
+RUN corepack enable
+
+COPY package.json yarn.lock .yarnrc.yml $APP_DIR/
+COPY packages/cms/package.json packages/cms/package.json
+COPY packages/cli/package.json packages/cli/package.json
+COPY packages/frontend/package.json packages/frontend/package.json
+COPY packages/shared/package.json packages/shared/package.json
+
+COPY packages/shared packages/shared
+COPY packages/cms packages/cms
+
+## Install application dependencies
+RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus @twreporter/congress-dashboard-cms @twreporter/congress-dashboard-shared
+
+RUN yarn workspace @twreporter/congress-dashboard-shared build
+
+## Build application bundles
+RUN yarn workspace @twreporter/congress-dashboard-cms build
+
+FROM node:22.23.1-slim AS production-deps
+
+ENV APP_DIR=/app
+
+WORKDIR $APP_DIR
+
+RUN corepack enable
+
+COPY package.json yarn.lock .yarnrc.yml $APP_DIR/
+COPY packages/cms/package.json packages/cms/package.json
+COPY packages/cli/package.json packages/cli/package.json
+COPY packages/frontend/package.json packages/frontend/package.json
+COPY packages/shared/package.json packages/shared/package.json
+
+COPY packages/shared packages/shared
+COPY packages/cms packages/cms
+
+## Install production application dependencies
+RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus @twreporter/congress-dashboard-cms --production && yarn cache clean
+COPY --from=build $APP_DIR/packages/shared/lib packages/shared/lib
+
+FROM node:22.23.1-slim AS runner
 
 ## Install system dependencies, `gcsfuse` in particular.
 RUN set -e; \
@@ -21,28 +67,30 @@ RUN set -e; \
     wget https://github.com/GoogleCloudPlatform/gcsfuse/releases/download/v1.2.0/gcsfuse_1.2.0_amd64.deb -O gcsfuse.deb && apt-get install -y ./gcsfuse.deb && rm -f ./gcsfuse.deb \
     && apt-get clean
 
-ENV APP_DIR /app
+ENV APP_DIR=/app
 ## Set fallback mount directory
-ENV MNT_DIR /app/gcs
-ENV HOST 0.0.0.0
-ENV PORT 3000
+ENV MNT_DIR=/app/packages/cms/gcs
+ENV HOST=0.0.0.0
+ENV PORT=3000
 
 RUN mkdir -p $APP_DIR
 
 WORKDIR $APP_DIR
 
-COPY . $APP_DIR
+RUN corepack enable
 
-## Install application dependencies
-RUN SKIP_BUILD_DEPS=true yarn install
+COPY --from=production-deps $APP_DIR/node_modules ./node_modules
+COPY --from=production-deps $APP_DIR/packages/cms/node_modules ./packages/cms/node_modules
+COPY --from=production-deps $APP_DIR/packages/shared/package.json ./packages/shared/package.json
+COPY --from=production-deps $APP_DIR/packages/shared/lib ./packages/shared/lib
 
-## Build application bundles
-RUN yarn build
-
-RUN yarn cache clean
+COPY packages/cms packages/cms
+COPY --from=build $APP_DIR/packages/cms/.keystone ./packages/cms/.keystone
 
 ## Ensure the script is executable
-RUN chmod +x run.sh
+RUN chmod +x packages/cms/run.sh
+
+WORKDIR $APP_DIR/packages/cms
 
 EXPOSE 3000
 
@@ -51,4 +99,4 @@ EXPOSE 3000
 ENTRYPOINT ["/usr/bin/tini", "--"]
 
 ## Pass the startup script as arguments to Tini
-CMD [ "/app/run.sh"]
+CMD [ "/app/packages/cms/run.sh"]

--- a/packages/cms/Dockerfile
+++ b/packages/cms/Dockerfile
@@ -12,13 +12,14 @@ COPY packages/cli/package.json packages/cli/package.json
 COPY packages/frontend/package.json packages/frontend/package.json
 COPY packages/shared/package.json packages/shared/package.json
 
-COPY packages/shared packages/shared
-COPY packages/cms packages/cms
-
 ## Install application dependencies
 RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus @twreporter/congress-dashboard-cms @twreporter/congress-dashboard-shared
 
+COPY packages/shared packages/shared
+COPY packages/cms packages/cms
+
 RUN yarn workspace @twreporter/congress-dashboard-shared build
+RUN yarn workspace @twreporter/congress-dashboard-cms postinstall
 
 ## Build application bundles
 RUN yarn workspace @twreporter/congress-dashboard-cms build
@@ -37,11 +38,10 @@ COPY packages/cli/package.json packages/cli/package.json
 COPY packages/frontend/package.json packages/frontend/package.json
 COPY packages/shared/package.json packages/shared/package.json
 
-COPY packages/shared packages/shared
-COPY packages/cms packages/cms
-
 ## Install production application dependencies
 RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus @twreporter/congress-dashboard-cms --production && yarn cache clean
+
+COPY packages/cms packages/cms
 COPY --from=build $APP_DIR/packages/shared/lib packages/shared/lib
 
 FROM node:22.23.1-slim AS runner
@@ -79,12 +79,12 @@ WORKDIR $APP_DIR
 
 RUN corepack enable
 
+COPY packages/cms packages/cms
+
 COPY --from=production-deps $APP_DIR/node_modules ./node_modules
 COPY --from=production-deps $APP_DIR/packages/cms/node_modules ./packages/cms/node_modules
 COPY --from=production-deps $APP_DIR/packages/shared/package.json ./packages/shared/package.json
 COPY --from=production-deps $APP_DIR/packages/shared/lib ./packages/shared/lib
-
-COPY packages/cms packages/cms
 COPY --from=build $APP_DIR/packages/cms/.keystone ./packages/cms/.keystone
 
 ## Ensure the script is executable

--- a/packages/cms/Dockerfile
+++ b/packages/cms/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM node:22.23.1-slim AS build
 
 ENV APP_DIR=/app
@@ -7,10 +9,7 @@ WORKDIR $APP_DIR
 RUN corepack enable
 
 COPY package.json yarn.lock .yarnrc.yml $APP_DIR/
-COPY packages/cms/package.json packages/cms/package.json
-COPY packages/cli/package.json packages/cli/package.json
-COPY packages/frontend/package.json packages/frontend/package.json
-COPY packages/shared/package.json packages/shared/package.json
+COPY --parents ./packages/*/package.json ./
 
 ## Install application dependencies
 RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus @twreporter/congress-dashboard-cms @twreporter/congress-dashboard-shared
@@ -33,10 +32,7 @@ WORKDIR $APP_DIR
 RUN corepack enable
 
 COPY package.json yarn.lock .yarnrc.yml $APP_DIR/
-COPY packages/cms/package.json packages/cms/package.json
-COPY packages/cli/package.json packages/cli/package.json
-COPY packages/frontend/package.json packages/frontend/package.json
-COPY packages/shared/package.json packages/shared/package.json
+COPY --parents ./packages/*/package.json ./
 
 ## Install production application dependencies
 RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus @twreporter/congress-dashboard-cms --production && yarn cache clean
@@ -79,16 +75,10 @@ RUN mkdir -p $APP_DIR
 
 WORKDIR $APP_DIR
 
-COPY --from=production-deps $APP_DIR/package.json $APP_DIR/.yarnrc.yml ./
+COPY --from=production-deps $APP_DIR $APP_DIR
 
 RUN corepack enable && corepack prepare yarn@4.6.0 --activate
 
-COPY packages/cms packages/cms
-
-COPY --from=production-deps $APP_DIR/node_modules ./node_modules
-COPY --from=production-deps $APP_DIR/packages/cms/node_modules ./packages/cms/node_modules
-COPY --from=production-deps $APP_DIR/packages/shared/package.json ./packages/shared/package.json
-COPY --from=production-deps $APP_DIR/packages/shared/lib ./packages/shared/lib
 COPY --from=build $APP_DIR/packages/cms/.keystone ./packages/cms/.keystone
 
 ## Ensure the script is executable

--- a/packages/cms/Dockerfile
+++ b/packages/cms/Dockerfile
@@ -77,7 +77,9 @@ RUN mkdir -p $APP_DIR
 
 WORKDIR $APP_DIR
 
-RUN corepack enable
+COPY --from=production-deps $APP_DIR/package.json $APP_DIR/.yarnrc.yml ./
+
+RUN corepack enable && corepack prepare yarn@4.6.0 --activate
 
 COPY packages/cms packages/cms
 

--- a/packages/cms/package.json
+++ b/packages/cms/package.json
@@ -7,7 +7,7 @@
     "start": "keystone start",
     "build": "keystone build --no-prisma",
     "db-migrate": "keystone prisma migrate deploy",
-    "postinstall": "keystone postinstall --fix",
+    "postinstall": "node -e \"if (process.env.SKIP_BUILD_DEPS !== 'true') require('child_process').execFileSync('keystone', ['postinstall', '--fix'], {stdio:'inherit'})\"",
     "generate-migrate": "keystone prisma migrate dev",
     "generate-migrate-preview": "keystone prisma migrate dev --create-only",
     "changelog-maker": "changelog-maker twreporter congress-dashboard-monorepo --markdown",

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 ARG NODE_VERSION=22.23.1
 
 FROM node:${NODE_VERSION}-alpine AS build
@@ -7,10 +9,7 @@ WORKDIR /repo
 RUN corepack enable
 
 COPY package.json yarn.lock .yarnrc.yml ./
-COPY packages/cms/package.json packages/cms/package.json
-COPY packages/cli/package.json packages/cli/package.json
-COPY packages/frontend/package.json packages/frontend/package.json
-COPY packages/shared/package.json packages/shared/package.json
+COPY --parents ./packages/*/package.json ./
 
 RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus @twreporter/congress-dashboard-frontend @twreporter/congress-dashboard-shared
 

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -1,23 +1,27 @@
 ARG NODE_VERSION=22.23.1
 
-FROM node:${NODE_VERSION} AS build
+FROM node:${NODE_VERSION}-alpine AS build
 
-WORKDIR /build
+WORKDIR /repo
 
-# NOTE: yarn.lock is not committed here. In CI (cloudbuild.yaml), it is copied
-# from the monorepo root into this directory before running `docker build`.
-# For local builds, run: cp ../../yarn.lock . before building.
-COPY package.json yarn.lock /build/
+RUN corepack enable
 
-RUN yarn install
+COPY package.json yarn.lock .yarnrc.yml ./
+COPY packages/cms/package.json packages/cms/package.json
+COPY packages/cli/package.json packages/cli/package.json
+COPY packages/frontend/package.json packages/frontend/package.json
+COPY packages/shared/package.json packages/shared/package.json
 
-COPY . /build/
+COPY packages/shared packages/shared
+COPY packages/frontend packages/frontend
 
-RUN yarn build
+RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus @twreporter/congress-dashboard-frontend @twreporter/congress-dashboard-shared
+RUN yarn workspace @twreporter/congress-dashboard-shared build
+RUN yarn workspace @twreporter/congress-dashboard-frontend build
 
 FROM node:${NODE_VERSION}-alpine AS runner
 
-ENV APP_DIR /app
+ENV APP_DIR=/app
 
 WORKDIR $APP_DIR
 
@@ -29,8 +33,8 @@ ENV NODE_OPTIONS="--network-family-autoselection-attempt-timeout=30000"
 RUN addgroup -S nextjs && adduser -S nextjs -G nextjs
 
 # Include only built files and necessary dependencies, with proper ownership
-COPY --from=build --chown=nextjs:nextjs /build/.next/standalone ./
-COPY --from=build --chown=nextjs:nextjs /build/.next/static ./.next/static
+COPY --from=build --chown=nextjs:nextjs /repo/packages/frontend/.next/standalone ./
+COPY --from=build --chown=nextjs:nextjs /repo/packages/frontend/.next/static ./.next/static
 
 USER nextjs
 

--- a/packages/frontend/Dockerfile
+++ b/packages/frontend/Dockerfile
@@ -12,10 +12,11 @@ COPY packages/cli/package.json packages/cli/package.json
 COPY packages/frontend/package.json packages/frontend/package.json
 COPY packages/shared/package.json packages/shared/package.json
 
+RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus @twreporter/congress-dashboard-frontend @twreporter/congress-dashboard-shared
+
 COPY packages/shared packages/shared
 COPY packages/frontend packages/frontend
 
-RUN SKIP_BUILD_DEPS=true YARN_ENABLE_IMMUTABLE_INSTALLS=true yarn workspaces focus @twreporter/congress-dashboard-frontend @twreporter/congress-dashboard-shared
 RUN yarn workspace @twreporter/congress-dashboard-shared build
 RUN yarn workspace @twreporter/congress-dashboard-frontend build
 

--- a/packages/frontend/src/app/robots.txt/route.ts
+++ b/packages/frontend/src/app/robots.txt/route.ts
@@ -1,3 +1,4 @@
+export const dynamic = 'force-static'
 const releaseBranch = process.env.NEXT_PUBLIC_RELEASE_BRANCH
 
 const releaseRobotsTxt = `

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,6 +23,7 @@
   ],
   "types": "lib/index.d.ts",
   "devDependencies": {
-    "tsup": "^8.3.6"
+    "tsup": "^8.3.6",
+    "typescript": "^5.8.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8639,6 +8639,7 @@ __metadata:
   resolution: "@twreporter/congress-dashboard-shared@workspace:packages/shared"
   dependencies:
     tsup: "npm:^8.3.6"
+    typescript: "npm:^5.8.3"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
# Issue
the dependency may not match `yarn.lock` when docker build

# Reason
- not set `--immutable` when `yarn install` in dockerfile

# Solution
- add immutable to yarn install
  - build from root
  - copy monorepo package.json so that yarn would know the dependency graph
- prevent unneccessary files been included in build image
  - apply multi-stage to dockerfile (`build`, `production-deps`, `runner`), and only copy neccessary files to runner stage
  - use `yarn workspace focus` to build target packages only
- for shared package, we used to manage it from npm. now add a `production-deps` stage to build shared package & copy built result

# Dependency
N/A
