### PR TITLE
fix(cms): use slug for speech/bill relationship, add scrollable-relationship field

### DIFF
--- a/packages/cms/lists/CouncilMember.ts
+++ b/packages/cms/lists/CouncilMember.ts
@@ -27,6 +27,7 @@ import {
   CITY_OPTIONS,
   CITY_LABEL,
 } from '@twreporter/congress-dashboard-shared/lib/constants/city'
+import { scrollableRelationship } from './fields/scrollable-relationship'
 
 const listConfigurations = list({
   fields: {
@@ -173,7 +174,7 @@ const listConfigurations = list({
       label: '是否該屆期現任',
       defaultValue: true,
     }),
-    speech: relationship({
+    speech: scrollableRelationship({
       ref: 'CouncilSpeech.councilMember',
       label: '縣市逐字稿',
       many: true,
@@ -187,7 +188,7 @@ const listConfigurations = list({
         },
       },
     }),
-    bill: relationship({
+    bill: scrollableRelationship({
       ref: 'CouncilBill.councilMember',
       label: '縣市議案',
       many: true,

--- a/packages/cms/lists/CouncilMember.ts
+++ b/packages/cms/lists/CouncilMember.ts
@@ -101,32 +101,6 @@ const listConfigurations = list({
         labelField: 'labelForCMS',
       },
     }),
-    speech: relationship({
-      ref: 'CouncilSpeech.councilMember',
-      label: '縣市逐字稿',
-      many: true,
-      ui: {
-        createView: {
-          fieldMode: 'hidden',
-        },
-        itemView: {
-          fieldMode: 'read',
-        },
-      },
-    }),
-    bill: relationship({
-      ref: 'CouncilBill.councilMember',
-      label: '縣市議案',
-      many: true,
-      ui: {
-        createView: {
-          fieldMode: 'hidden',
-        },
-        itemView: {
-          fieldMode: 'read',
-        },
-      },
-    }),
     type: select({
       label: '類別',
       options: MEMBER_TYPE_OPTIONS,
@@ -198,6 +172,34 @@ const listConfigurations = list({
     isActive: checkbox({
       label: '是否該屆期現任',
       defaultValue: true,
+    }),
+    speech: relationship({
+      ref: 'CouncilSpeech.councilMember',
+      label: '縣市逐字稿',
+      many: true,
+      ui: {
+        labelField: 'slug',
+        createView: {
+          fieldMode: 'hidden',
+        },
+        itemView: {
+          fieldMode: 'read',
+        },
+      },
+    }),
+    bill: relationship({
+      ref: 'CouncilBill.councilMember',
+      label: '縣市議案',
+      many: true,
+      ui: {
+        labelField: 'slug',
+        createView: {
+          fieldMode: 'hidden',
+        },
+        itemView: {
+          fieldMode: 'read',
+        },
+      },
     }),
     createdAt: CREATED_AT(),
     updatedAt: UPDATED_AT(),

--- a/packages/cms/lists/CouncilTopic.ts
+++ b/packages/cms/lists/CouncilTopic.ts
@@ -33,7 +33,7 @@ const listConfigurations = list({
       label: '縣市逐字稿',
       many: true,
       ui: {
-        labelField: 'title',
+        labelField: 'slug',
       },
     }),
     bill: relationship({
@@ -41,7 +41,7 @@ const listConfigurations = list({
       label: '縣市議案',
       many: true,
       ui: {
-        labelField: 'title',
+        labelField: 'slug',
       },
     }),
     city: select({

--- a/packages/cms/lists/CouncilTopic.ts
+++ b/packages/cms/lists/CouncilTopic.ts
@@ -19,6 +19,7 @@ import {
   COUNCIL_TOPIC_TYPE_OPTIONS,
   COUNCIL_TOPIC_TYPE,
 } from '@twreporter/congress-dashboard-shared/lib/constants/council-topic'
+import { scrollableRelationship } from './fields/scrollable-relationship'
 
 const listConfigurations = list({
   fields: {
@@ -28,7 +29,7 @@ const listConfigurations = list({
       isIndexed: true,
     }),
     slug: SLUG,
-    speech: relationship({
+    speech: scrollableRelationship({
       ref: 'CouncilSpeech.topic',
       label: '縣市逐字稿',
       many: true,
@@ -36,7 +37,7 @@ const listConfigurations = list({
         labelField: 'slug',
       },
     }),
-    bill: relationship({
+    bill: scrollableRelationship({
       ref: 'CouncilBill.topic',
       label: '縣市議案',
       many: true,

--- a/packages/cms/lists/LegislativeYuanMember.ts
+++ b/packages/cms/lists/LegislativeYuanMember.ts
@@ -24,6 +24,7 @@ import {
   CONSTITUENCY_OPTIONS,
 } from '@twreporter/congress-dashboard-shared/lib/constants/legislative-yuan-member'
 import { CITY_OPTIONS } from '@twreporter/congress-dashboard-shared/lib/constants/city'
+import { scrollableRelationship } from './fields/scrollable-relationship'
 
 const listConfigurations = list({
   fields: {
@@ -99,7 +100,7 @@ const listConfigurations = list({
         labelField: 'term',
       },
     }),
-    speeches: relationship({
+    speeches: scrollableRelationship({
       ref: 'Speech.legislativeYuanMember',
       label: '發言紀錄',
       many: true,

--- a/packages/cms/lists/LegislativeYuanMember.ts
+++ b/packages/cms/lists/LegislativeYuanMember.ts
@@ -104,6 +104,7 @@ const listConfigurations = list({
       label: '發言紀錄',
       many: true,
       ui: {
+        labelField: 'slug',
         createView: {
           fieldMode: 'hidden',
         },

--- a/packages/cms/lists/Topic.ts
+++ b/packages/cms/lists/Topic.ts
@@ -11,6 +11,7 @@ import {
 } from './utils/access-control-list'
 import { SLUG, CREATED_AT, UPDATED_AT } from './utils/common-field'
 import { logger } from '../utils/logger'
+import { scrollableRelationship } from './fields/scrollable-relationship'
 
 const listConfigurations = list({
   fields: {
@@ -20,7 +21,7 @@ const listConfigurations = list({
       isIndexed: true,
     }),
     slug: SLUG,
-    speeches: relationship({
+    speeches: scrollableRelationship({
       ref: 'Speech.topics',
       label: '逐字稿',
       many: true,

--- a/packages/cms/lists/Topic.ts
+++ b/packages/cms/lists/Topic.ts
@@ -25,7 +25,7 @@ const listConfigurations = list({
       label: '逐字稿',
       many: true,
       ui: {
-        labelField: 'title',
+        labelField: 'slug',
       },
     }),
     relatedTopics: relationship({

--- a/packages/cms/lists/fields/scrollable-relationship.ts
+++ b/packages/cms/lists/fields/scrollable-relationship.ts
@@ -1,0 +1,16 @@
+import { relationship } from '@keystone-6/core/fields'
+
+type RelationshipConfig = Parameters<typeof relationship>[0]
+
+/**
+ * A Keystone relationship that uses the native relationship UI with an
+ * opt-in height limit for its selected values.
+ */
+export const scrollableRelationship = (config: RelationshipConfig) => {
+  const relationshipField = relationship(config)
+
+  return (...args: Parameters<typeof relationshipField>) => ({
+    ...relationshipField(...args),
+    views: './lists/views/scrollable-relationship',
+  })
+}

--- a/packages/cms/lists/views/scrollable-relationship/index.tsx
+++ b/packages/cms/lists/views/scrollable-relationship/index.tsx
@@ -15,8 +15,8 @@ export { CardValue, Cell, controller }
 const FieldContainer = styled.div`
   /*
    * Keystone does not currently expose RelationshipSelect's styles prop.
-   * Scope this selector to opted-in fields and anchor it to the combobox's
-   * accessible attributes instead of generated Emotion class names.
+   * Scope this selector to opted-in fields and anchor it to the relationship
+   * field's DOM structure (fieldset > div) instead of generated Emotion class names.
    */
   fieldset > div {
     max-height: 200px;

--- a/packages/cms/lists/views/scrollable-relationship/index.tsx
+++ b/packages/cms/lists/views/scrollable-relationship/index.tsx
@@ -1,0 +1,33 @@
+/** @jsxRuntime classic */
+/** @jsx jsx */
+import styled from '@emotion/styled'
+import { jsx } from '@keystone-ui/core'
+import type { ComponentProps } from 'react'
+import {
+  Field as KeystoneRelationshipField,
+  CardValue,
+  Cell,
+  controller,
+} from '@keystone-6/core/fields/types/relationship/views'
+
+export { CardValue, Cell, controller }
+
+const FieldContainer = styled.div`
+  /*
+   * Keystone does not currently expose RelationshipSelect's styles prop.
+   * Scope this selector to opted-in fields and anchor it to the combobox's
+   * accessible attributes instead of generated Emotion class names.
+   */
+  fieldset > div {
+    max-height: 200px;
+    overflow-y: auto !important;
+  }
+`
+
+export function Field(props: ComponentProps<typeof KeystoneRelationshipField>) {
+  return (
+    <FieldContainer>
+      <KeystoneRelationshipField {...props} />
+    </FieldContainer>
+  )
+}

--- a/packages/cms/schema.graphql
+++ b/packages/cms/schema.graphql
@@ -1487,10 +1487,6 @@ type CouncilMember {
   labelForCMS: String
   party: Party
   councilMeeting: CouncilMeeting
-  speech(where: CouncilSpeechWhereInput! = {}, orderBy: [CouncilSpeechOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CouncilSpeechWhereUniqueInput): [CouncilSpeech!]
-  speechCount(where: CouncilSpeechWhereInput! = {}): Int
-  bill(where: CouncilBillWhereInput! = {}, orderBy: [CouncilBillOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CouncilBillWhereUniqueInput): [CouncilBill!]
-  billCount(where: CouncilBillWhereInput! = {}): Int
   type: String
   city: String
   constituency: Int
@@ -1500,6 +1496,10 @@ type CouncilMember {
   proposalSuccessCount: Int
   relatedLink: JSON
   isActive: Boolean
+  speech(where: CouncilSpeechWhereInput! = {}, orderBy: [CouncilSpeechOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CouncilSpeechWhereUniqueInput): [CouncilSpeech!]
+  speechCount(where: CouncilSpeechWhereInput! = {}): Int
+  bill(where: CouncilBillWhereInput! = {}, orderBy: [CouncilBillOrderByInput!]! = [], take: Int, skip: Int! = 0, cursor: CouncilBillWhereUniqueInput): [CouncilBill!]
+  billCount(where: CouncilBillWhereInput! = {}): Int
   createdAt: DateTime
   updatedAt: DateTime
 }
@@ -1517,14 +1517,14 @@ input CouncilMemberWhereInput {
   labelForCMS: StringFilter
   party: PartyWhereInput
   councilMeeting: CouncilMeetingWhereInput
-  speech: CouncilSpeechManyRelationFilter
-  bill: CouncilBillManyRelationFilter
   type: StringFilter
   city: StringFilter
   constituency: IntNullableFilter
   tooltip: StringFilter
   note: StringFilter
   isActive: BooleanFilter
+  speech: CouncilSpeechManyRelationFilter
+  bill: CouncilBillManyRelationFilter
   createdAt: DateTimeNullableFilter
   updatedAt: DateTimeNullableFilter
 }
@@ -1547,8 +1547,6 @@ input CouncilMemberUpdateInput {
   labelForCMS: String
   party: PartyRelateToOneForUpdateInput
   councilMeeting: CouncilMeetingRelateToOneForUpdateInput
-  speech: CouncilSpeechRelateToManyForUpdateInput
-  bill: CouncilBillRelateToManyForUpdateInput
   type: String
   city: String
   constituency: Int
@@ -1557,6 +1555,8 @@ input CouncilMemberUpdateInput {
   note: String
   relatedLink: JSON
   isActive: Boolean
+  speech: CouncilSpeechRelateToManyForUpdateInput
+  bill: CouncilBillRelateToManyForUpdateInput
   createdAt: DateTime
   updatedAt: DateTime
 }
@@ -1577,8 +1577,6 @@ input CouncilMemberCreateInput {
   labelForCMS: String
   party: PartyRelateToOneForCreateInput
   councilMeeting: CouncilMeetingRelateToOneForCreateInput
-  speech: CouncilSpeechRelateToManyForCreateInput
-  bill: CouncilBillRelateToManyForCreateInput
   type: String
   city: String
   constituency: Int
@@ -1587,6 +1585,8 @@ input CouncilMemberCreateInput {
   note: String
   relatedLink: JSON
   isActive: Boolean
+  speech: CouncilSpeechRelateToManyForCreateInput
+  bill: CouncilBillRelateToManyForCreateInput
   createdAt: DateTime
   updatedAt: DateTime
 }

--- a/packages/cms/schema.prisma
+++ b/packages/cms/schema.prisma
@@ -295,8 +295,6 @@ model CouncilMember {
   partyId                Int?            @map("party")
   councilMeeting         CouncilMeeting? @relation("CouncilMember_councilMeeting", fields: [councilMeetingId], references: [id])
   councilMeetingId       Int?            @map("councilMeeting")
-  speech                 CouncilSpeech[] @relation("CouncilSpeech_councilMember")
-  bill                   CouncilBill[]   @relation("CouncilBill_councilMember")
   type                   String
   city                   String
   constituency           Int?
@@ -305,6 +303,8 @@ model CouncilMember {
   note                   String          @default("")
   relatedLink            Json?
   isActive               Boolean         @default(true)
+  speech                 CouncilSpeech[] @relation("CouncilSpeech_councilMember")
+  bill                   CouncilBill[]   @relation("CouncilBill_councilMember")
   createdAt              DateTime?       @default(now())
   updatedAt              DateTime?       @updatedAt
 

--- a/packages/frontend/src/app/api/council-topic/query.ts
+++ b/packages/frontend/src/app/api/council-topic/query.ts
@@ -30,6 +30,7 @@ const fetchTopNCouncilTopics = async ({
           imageLink
           slug
           party
+          count
           image {
             imageFile {
               url


### PR DESCRIPTION
# Issue
[[觀測站CMS] 逐字稿/發言紀錄 顯示名稱改為 slug ](https://app.notion.com/p/twreporter/CMS-slug-3b58dbdca932808da200fb6e3dc604d5?source=copy_link)
[[觀測站CMS] 逐字稿、議案關聯區塊新增固定高度滑動](https://app.notion.com/p/twreporter/CMS-3b58dbdca93280148416f6fdb9a8b0d0?source=copy_link)
[[defect] 2026/8/7共1處](https://app.notion.com/p/twreporter/defect-2026-8-7-1-3b58dbdca932805d955dd0cb0d0dac38?source=copy_link)
[[觀測站] 縣市議會看議題載入更多會出現 undefined](https://app.notion.com/p/twreporter/undefined-3b18dbdca93280cb9fbdf4b95f8579c9?source=copy_link)

# Dependency
N/A
